### PR TITLE
wrap Spew in t.Log to minimize noise and add line numbers

### DIFF
--- a/crypt_test.go
+++ b/crypt_test.go
@@ -45,7 +45,7 @@ func TestDecrypt(t *testing.T) {
 	var body AuthenStart
 	err = Unmarshal(packet.Body, &body)
 	assert.NoError(t, err)
-	spew.Dump(body)
+	t.Log(spew.Sdump(body))
 }
 
 func TestEncrypt(t *testing.T) {
@@ -72,14 +72,14 @@ func TestEncrypt(t *testing.T) {
 		),
 		SetPacketBody(body),
 	)
-	spew.Dump(packet)
+	t.Log(spew.Sdump(packet))
 	err := crypt([]byte("fooman"), packet)
 	assert.NoError(t, err)
-	spew.Dump(packet)
+	t.Log(spew.Sdump(packet))
 	assert.Equal(t, encrypted[12:], packet.Body)
 	err = crypt([]byte("fooman"), packet)
 	assert.NoError(t, err)
-	spew.Dump(packet)
+	t.Log(spew.Sdump(packet))
 	assert.Equal(t, decrypted, packet.Body)
 }
 

--- a/packet_test.go
+++ b/packet_test.go
@@ -73,12 +73,12 @@ func TestHeaderMarshalUnmarshal(t *testing.T) {
 
 	buf, err := v.MarshalBinary()
 	assert.NoError(t, err)
-	spew.Dump(buf)
+	t.Log(spew.Sdump(buf))
 
 	decoded := &Header{}
 	err = decoded.UnmarshalBinary(buf)
 	assert.NoError(t, err)
-	spew.Dump(decoded)
+	t.Log(spew.Sdump(decoded))
 	assert.Equal(t, v, decoded)
 }
 
@@ -93,12 +93,12 @@ func TestAuthenStartMarshalUnmarshal(t *testing.T) {
 	)
 	buf, err := v.MarshalBinary()
 	assert.NoError(t, err)
-	spew.Dump(buf)
+	t.Log(spew.Sdump(buf))
 
 	decoded := &AuthenStart{}
 	err = decoded.UnmarshalBinary(buf)
 	assert.NoError(t, err)
-	spew.Dump(decoded)
+	t.Log(spew.Sdump(decoded))
 	assert.Equal(t, v, decoded)
 }
 
@@ -110,12 +110,12 @@ func TestAuthenReplyMarshalUnmarshal(t *testing.T) {
 
 	buf, err := v.MarshalBinary()
 	assert.NoError(t, err)
-	spew.Dump(buf)
+	t.Log(spew.Sdump(buf))
 
 	decoded := &AuthenReply{}
 	err = decoded.UnmarshalBinary(buf)
 	assert.NoError(t, err)
-	spew.Dump(decoded)
+	t.Log(spew.Sdump(decoded))
 	assert.Equal(t, v, decoded)
 }
 
@@ -126,12 +126,12 @@ func TestAuthenContinueMarshalUnmarshal(t *testing.T) {
 
 	buf, err := v.MarshalBinary()
 	assert.NoError(t, err)
-	spew.Dump(buf)
+	t.Log(spew.Sdump(buf))
 
 	decoded := &AuthenContinue{}
 	err = decoded.UnmarshalBinary(buf)
 	assert.NoError(t, err)
-	spew.Dump(decoded)
+	t.Log(spew.Sdump(decoded))
 	assert.Equal(t, v, decoded)
 }
 
@@ -157,12 +157,12 @@ func TestAuthorRequestMarshalUnmarshal(t *testing.T) {
 	)
 	buf, err := v.MarshalBinary()
 	assert.Nil(t, err)
-	spew.Dump(buf)
+	t.Log(spew.Sdump(buf))
 
 	decoded := &AuthorRequest{}
 	err = decoded.UnmarshalBinary(buf)
 	assert.NoError(t, err)
-	spew.Dump(decoded)
+	t.Log(spew.Sdump(decoded))
 	assert.Equal(t, v, decoded)
 
 	// arg is too short < 2
@@ -201,12 +201,12 @@ func TestAuthorReplyMarshalUnmarshal(t *testing.T) {
 	)
 	buf, err := v.MarshalBinary()
 	assert.NoError(t, err)
-	spew.Dump(buf)
+	t.Log(spew.Sdump(buf))
 
 	decoded := &AuthorReply{}
 	err = decoded.UnmarshalBinary(buf)
 	assert.NoError(t, err)
-	spew.Dump(decoded)
+	t.Log(spew.Sdump(decoded))
 	assert.Equal(t, v, decoded)
 }
 
@@ -226,12 +226,12 @@ func TestAcctRequestMarshalUnmarshal(t *testing.T) {
 
 	buf, err := v.MarshalBinary()
 	assert.NoError(t, err)
-	spew.Dump(buf)
+	t.Log(spew.Sdump(buf))
 
 	decoded := &AcctRequest{}
 	err = decoded.UnmarshalBinary(buf)
 	assert.NoError(t, err)
-	spew.Dump(decoded)
+	t.Log(spew.Sdump(decoded))
 	assert.Equal(t, v, decoded)
 }
 
@@ -243,12 +243,12 @@ func TestAcctReplyMarshalUnmarshal(t *testing.T) {
 	)
 	buf, err := v.MarshalBinary()
 	assert.NoError(t, err)
-	spew.Dump(buf)
+	t.Log(spew.Sdump(buf))
 
 	decoded := &AcctReply{}
 	err = decoded.UnmarshalBinary(buf)
 	assert.NoError(t, err)
-	spew.Dump(decoded)
+	t.Log(spew.Sdump(decoded))
 	assert.Equal(t, v, decoded)
 }
 


### PR DESCRIPTION
Wraps spew output in t.Log. This hides output from passing tests by default so you can better focus on broken tests.
t.Log also writes filename and line number so you can jump straight to the test without having to `grep` to find where a test was implemented.

# Before
No indication of which spew corresponded to what test case. No line numbers.

Default:
```
jda@tangent:~/Projects/tacquito$ go test
(tacquito.AuthenStart) {
 Action: (tacquito.AuthenAction) AuthenActionLogin,
 PrivLvl: (tacquito.PrivLvl) PrivLvlUser,
 Type: (tacquito.AuthenType) AuthenTypeASCII,
 Service: (tacquito.AuthenService) AuthenServiceLogin,
 User: (tacquito.AuthenUser) (len=5) admin,
 Port: (tacquito.AuthenPort) (len=11) command-api,
 RemAddr: (tacquito.AuthenRemAddr) (len=20) 2001:4860:4860::8888,
 Data: (tacquito.AuthenData)
}
[...]
```
With verbose flag:
```
jda@tangent:~/Projects/tacquito$ go test -v
=== RUN   TestDecrypt
(tacquito.AuthenStart) {
 Action: (tacquito.AuthenAction) AuthenActionLogin,
 PrivLvl: (tacquito.PrivLvl) PrivLvlUser,
 Type: (tacquito.AuthenType) AuthenTypeASCII,
 Service: (tacquito.AuthenService) AuthenServiceLogin,
 User: (tacquito.AuthenUser) (len=5) admin,
 Port: (tacquito.AuthenPort) (len=11) command-api,
 RemAddr: (tacquito.AuthenRemAddr) (len=20) 2001:4860:4860::8888,
 Data: (tacquito.AuthenData)
}
--- PASS: TestDecrypt (0.00s)
[...]
```

# After
Default:
```
jda@tangent:~/Projects/tacquito$ go test
PASS
ok      github.com/facebookincubator/tacquito   0.015s
```
With verbose flag:
```
jda@tangent:~/Projects/tacquito$ go test -v
=== RUN   TestDecrypt
    crypt_test.go:48: (tacquito.AuthenStart) {
         Action: (tacquito.AuthenAction) AuthenActionLogin,
         PrivLvl: (tacquito.PrivLvl) PrivLvlUser,
         Type: (tacquito.AuthenType) AuthenTypeASCII,
         Service: (tacquito.AuthenService) AuthenServiceLogin,
         User: (tacquito.AuthenUser) (len=5) admin,
         Port: (tacquito.AuthenPort) (len=11) command-api,
         RemAddr: (tacquito.AuthenRemAddr) (len=20) 2001:4860:4860::8888,
         Data: (tacquito.AuthenData)
        }

--- PASS: TestDecrypt (0.00s)
[...]
```