### PR TITLE
trivial: fix doc example of command line to run client

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cd cmds/server && go run .
 ```
 ### Client
 ```
-cd cmds/client && go . -username cisco -password cisco
+cd cmds/client && go run . -username cisco -password cisco
 ```
 
 Running the above will show a simple authentication exchange.


### PR DESCRIPTION
Example to run the demo client was missing `run` from `go run`

# Before
```
jda@tangent:~/Projects/tacquito/cmds/client$ go . -username cisco -password cisco
go .: unknown command
Run 'go help' for usage.
```
# After
```
jda@tangent:~/Projects/tacquito/cmds/client$ go run . -username cisco -password cisco
execute pap authentication

{Status:AuthenStatusPass Flags: ServerMsg:login success Data:}
```