### PR TITLE
fix: client: sending username instead of password for ascii authentic…

### DIFF
--- a/cmds/client/authen_ascii.go
+++ b/cmds/client/authen_ascii.go
@@ -109,7 +109,7 @@ func newASCIIAuthenSequence(password string) []asciiSequence {
 			),
 			tq.SetPacketBodyUnsafe(
 				tq.NewAuthenContinue(
-					tq.SetAuthenContinueUserMessage(tq.AuthenUserMessage(*username)),
+					tq.SetAuthenContinueUserMessage(tq.AuthenUserMessage(password)),
 				),
 			),
 		),


### PR DESCRIPTION
Hi I noticed when playing around with the example client that the when using the ascii authentication method the client is replying to the servers `TAC_PLUS_AUTHEN_STATUS_GETPASS` request with the username rather than the password. This PR addresses that issue