### PR TITLE
fix bug

### DIFF
--- a/cmds/client/authen_ascii.go
+++ b/cmds/client/authen_ascii.go
@@ -109,7 +109,7 @@ func newASCIIAuthenSequence(password string) []asciiSequence {
 			),
 			tq.SetPacketBodyUnsafe(
 				tq.NewAuthenContinue(
-					tq.SetAuthenContinueUserMessage(tq.AuthenUserMessage(*username)),
+					tq.SetAuthenContinueUserMessage(tq.AuthenUserMessage(password)),
 				),
 			),
 		),


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/tacquito/pull/7/ brought this to our attention. Fixing it from our side
Tldr; the authen client code sends the username in the Authen packet instead of the password. The current default username/password is cisco/cisco, and my guess is that username and password being the same is the reason this bug wasn't caught in initial tests.
fix now sends the password instead of the username.

Reviewed By: shringiarpit26

Differential Revision: D49964575


