### PR TITLE
Fix cmd match stringy

### DIFF
--- a/authorize_fields.go
+++ b/authorize_fields.go
@@ -194,6 +194,28 @@ func (t Args) CommandArgs() string {
 	return strings.Join(args, " ")
 }
 
+// isLineEnding returns true if a is a valid line ending for tacacs authorization
+// payload
+func isLineEnding(a string) bool {
+	return strings.ToLower(a) == "<cr>"
+}
+
+// CommandArgsNoLE joins all cmd-arg args into a single string
+// and ignores line endings, specifically <cr>
+func (t Args) CommandArgsNoLE() string {
+	args := make([]string, 0, len(t))
+	for idx, arg := range t {
+		a, _, v := arg.ASV()
+		if a == "cmd-arg" {
+			if idx == len(t)-1 && isLineEnding(v) {
+				continue
+			}
+			args = append(args, v)
+		}
+	}
+	return strings.Join(args, " ")
+}
+
 // Args splits the Args into cmd, cmd-arg and other=arg
 // the key is the left side of the delimiter, etc
 func (t Args) Args() []string {

--- a/authorize_fields_test.go
+++ b/authorize_fields_test.go
@@ -1,4 +1,3 @@
-	
 /*
  Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -14,18 +13,18 @@ import (
 
 func TestArgsStripCR(t *testing.T) {
 
-	tests := []Args {
+	tests := []Args{
 
-	{
-		"cmd=show",
-		"cmd-arg=version",
-		"cmd-arg=<cr>",
-	},
-	{
-		"cmd=show",
-		"cmd-arg=version",
-		"cmd-arg=<Cr>",
-	},
+		{
+			"cmd=show",
+			"cmd-arg=version",
+			"cmd-arg=<cr>",
+		},
+		{
+			"cmd=show",
+			"cmd-arg=version",
+			"cmd-arg=<Cr>",
+		},
 	}
 	expected := "version"
 	for _, args := range tests {

--- a/authorize_fields_test.go
+++ b/authorize_fields_test.go
@@ -1,0 +1,52 @@
+	
+/*
+ Copyright (c) Facebook, Inc. and its affiliates.
+
+ This source code is licensed under the MIT license found in the
+ LICENSE file in the root directory of this source tree.
+*/
+
+package tacquito
+
+import (
+	"testing"
+)
+
+func TestArgsStripCR(t *testing.T) {
+
+	tests := []Args {
+
+	{
+		"cmd=show",
+		"cmd-arg=version",
+		"cmd-arg=<cr>",
+	},
+	{
+		"cmd=show",
+		"cmd-arg=version",
+		"cmd-arg=<Cr>",
+	},
+	}
+	expected := "version"
+	for _, args := range tests {
+		if v := args.CommandArgsNoLE(); v != expected {
+			t.Fatalf("failed to get command args, expected %s, got %s", expected, v)
+		}
+	}
+}
+
+func TestArgsStripCRInMiddle(t *testing.T) {
+	args := Args{
+		"cmd=show",
+		"cmd-arg=version",
+		"cmd-arg=<cr>",
+		"cmd-arg=actual",
+		"cmd-arg=line",
+		"cmd-arg=ending",
+		"cmd-arg=<cr>",
+	}
+	expected := "version <cr> actual line ending"
+	if v := args.CommandArgsNoLE(); v != expected {
+		t.Fatalf("failed to get command args, expected %s, got %s", expected, v)
+	}
+}

--- a/cmds/server/config/authorizers/stringy/test/stringy_test.go
+++ b/cmds/server/config/authorizers/stringy/test/stringy_test.go
@@ -152,6 +152,44 @@ func TestCommands(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "cisco; service=shell, cmd=check for regex boundaries",
+			user: config.User{
+				Name: "cisco",
+				Commands: []config.Command{
+					{
+						Name:   "bash",
+						Match:  []string{"cat.*"},
+						Action: config.PERMIT,
+					},
+				},
+			},
+			request: newAuthorRequest("cisco", tq.Args{"service=shell", "cmd=bash", "cmd-arg=/etc/some_folder/file_name_contains_cat.sh"}),
+			validate: func(name string, response *mockedResponse) {
+				if response.got.Status != tq.AuthorStatusFail {
+					assert.Fail(t, fmt.Sprintf("[%v] should have had a status of [%v] but got [%v]", name, tq.AuthorStatusFail, response.got.Status))
+				}
+			},
+		},
+		{
+			name: "cisco; service=shell, cmd=check that boundaries are not added if they are already set",
+			user: config.User{
+				Name: "cisco",
+				Commands: []config.Command{
+					{
+						Name:   "bash",
+						Match:  []string{"^cat.*$"},
+						Action: config.PERMIT,
+					},
+				},
+			},
+			request: newAuthorRequest("cisco", tq.Args{"service=shell", "cmd=bash", "cmd-arg=cat", "cmd-arg=/etc/some_folder/file_name_contains_cat.sh"}),
+			validate: func(name string, response *mockedResponse) {
+				if response.got.Status != tq.AuthorStatusPassAdd {
+					assert.Fail(t, fmt.Sprintf("[%v] should have had a status of [%v] but got [%v]", name, tq.AuthorStatusPassAdd, response.got.Status))
+				}
+			},
+		},
 	}
 	for _, test := range tests {
 		logger.Infof(ctx, "running test [%v]", test.name)
@@ -498,3 +536,4 @@ func TestSessionsAndServices(t *testing.T) {
 		test.validate(test.name, resp)
 	}
 }
+


### PR DESCRIPTION
This PR fixes the regex matching algorithm in tacquito's default authorizer by adding boundary conditions around the contents of the match attribute of commands.