### PR TITLE
Tacacs tls support

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,7 +29,7 @@ func SetClientDialer(network, address string, secret []byte) ClientOption {
 		if err != nil {
 			return err
 		}
-		c.crypter = newCrypter(secret, conn, false)
+		c.crypter = newCrypter(secret, conn, false, false)
 		return nil
 	}
 }
@@ -39,7 +39,7 @@ func SetClientDialer(network, address string, secret []byte) ClientOption {
 // A secret for the connection must also be provided.
 func SetClientWithConn(conn *net.TCPConn, secret []byte) ClientOption {
 	return func(c *Client) error {
-		c.crypter = newCrypter(secret, conn, false)
+		c.crypter = newCrypter(secret, conn, false, false)
 		return nil
 	}
 }
@@ -64,7 +64,7 @@ func SetClientDialerWithLocalAddr(network, raddr, laddr string, secret []byte) C
 		if err != nil {
 			return err
 		}
-		c.crypter = newCrypter(secret, conn, false)
+		c.crypter = newCrypter(secret, conn, false, false)
 		return nil
 	}
 }

--- a/cmds/client/main.go
+++ b/cmds/client/main.go
@@ -30,24 +30,25 @@ var (
 	authenMode = flag.String("authen-mode", "pap", "valid choices, [pap ascii]")
 
 	// TLS options
-	useTLS                = flag.Bool("tls", false, "enable TLS support as per IETF draft-ietf-opsawg-tacacs-tls13-07")
-	tlsCertFile           = flag.String("tls-cert", "", "path to TLS client certificate file")
-	tlsKeyFile            = flag.String("tls-key", "", "path to TLS client key file")
-	tlsCAFile             = flag.String("tls-ca", "", "path to TLS CA certificate file for server certificate validation")
-	tlsServerName         = flag.String("tls-server-name", "", "server name for TLS certificate validation")
-	tlsInsecureSkipVerify = flag.Bool("tls-insecure-skip-verify", false, "skip TLS certificate verification (not recommended for production)")
+	tlsConfigFile = flag.String("tls-config", "", "path to TLS configuration file in JSON format. When set, the values inside the file this will override all other TLS cmdline flags")
 )
 
 func main() {
 	flag.Parse()
+
 	verifyFlags()
 
 	var c *tq.Client
 	var err error
 
-	if *useTLS {
+	if *tlsConfigFile != "" {
+		config, err := tq.LoadTLSConfig(*tlsConfigFile)
+		if err != nil {
+			fmt.Printf("Error loading TLS config file: %v\n", err)
+			os.Exit(1)
+		}
 		// Create TLS configuration
-		tlsConfig, tlsErr := tq.GenClientTLSConfig(*tlsServerName, *tlsCertFile, *tlsKeyFile, *tlsCAFile, *tlsInsecureSkipVerify)
+		tlsConfig, tlsErr := tq.GenClientTLSConfig(config)
 		if tlsErr != nil {
 			fmt.Printf("Error creating TLS config: %v\n", tlsErr)
 			os.Exit(1)

--- a/cmds/client/tls.conf
+++ b/cmds/client/tls.conf
@@ -1,0 +1,7 @@
+{
+  "cert_file": "./client.crt",
+  "key_file": "./client.key",
+  "ca_file": "./ca.crt",
+  "server_name": "localhost",
+  "insecure_skip_verify": false
+}

--- a/cmds/server/test/server_tls_bench_test.go
+++ b/cmds/server/test/server_tls_bench_test.go
@@ -1,0 +1,212 @@
+/*
+ Copyright (c) Facebook, Inc. and its affiliates.
+
+ This source code is licensed under the MIT license found in the
+ LICENSE file in the root directory of this source tree.
+*/
+
+package test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tq "github.com/facebookincubator/tacquito"
+	"github.com/facebookincubator/tacquito/cmds/server/log"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// GenerateTLSCertificate is part of the public API for this package
+// can be overridden for other functions (such as the generateOptimizedTLSCertificate)
+var GenerateTLSCertificate = generateTLSCertificate
+
+// GenerateTLSCertificate generates a temporary TLS certificate and key in the given directory
+// this can be utilized by the test to create TLS test specific config
+func generateTLSCertificate(testDir string) (certFile, keyFile string, tlsConfig *tls.Config, err error) {
+	// Generate private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	// Create certificate template
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization:  []string{"Test Corp"},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"Test City"},
+			StreetAddress: []string{""},
+			PostalCode:    []string{""},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.IPv6loopback, net.ParseIP("::1")},
+		DNSNames:              []string{"localhost"},
+	}
+
+	// Create certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	// Write certificate to file
+	certFile = filepath.Join(testDir, "cert.pem")
+	certOut, err := os.Create(certFile)
+	if err != nil {
+		return "", "", nil, err
+	}
+	defer certOut.Close()
+
+	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	// Write private key to file
+	keyFile = filepath.Join(testDir, "key.pem")
+	keyOut, err := os.Create(keyFile)
+	if err != nil {
+		return "", "", nil, err
+	}
+	defer keyOut.Close()
+
+	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	err = pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: privKeyBytes})
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	// Load certificate and create TLS config
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	tlsConfig = &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		InsecureSkipVerify: true, // For test purposes
+	}
+
+	return certFile, keyFile, tlsConfig, nil
+}
+
+/* Base line results
+goos: linux
+goarch: amd64
+pkg: github.com/facebookincubator/tacquito/cmds/server/test
+cpu: Intel Core Processor (Broadwell)
+BenchmarkPacketExchangeAsciiLoginUsingSharedClientTLS-72              44          73866034 ns/op           35767 B/op        454 allocs/op
+BenchmarkPacketExchangeAsciiLoginUsingNewClientTLS-72                 43          78560658 ns/op          139176 B/op       1230 allocs/op
+PASS
+*/
+
+// BenchmarkPacketExchangeAsciiLoginUsingSharedClientTLS will test the full ascii login flow
+// using a single TLS client instance
+func BenchmarkPacketExchangeAsciiLoginUsingSharedClientTLS(b *testing.B) {
+	testDir := b.TempDir()
+	_, _, serverTLSConfig, err := GenerateTLSCertificate(testDir)
+	assert.NoError(b, err)
+
+	logger := log.New(0, io.Discard) // no logs
+	ctx := context.Background()
+	sp, err := MockSecretProvider(ctx, logger, "testdata/test_config.yaml")
+	assert.NoError(b, err)
+
+	// Create TLS listener
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	assert.NoError(b, err)
+	tlsListener, err := tq.NewTLSListener(listener, serverTLSConfig)
+	assert.NoError(b, err)
+
+	s := tq.NewServer(logger, sp, tq.SetUseTLS(true))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		if err := s.Serve(ctx, tlsListener); err != nil {
+			assert.NoError(b, err)
+		}
+	}()
+
+	// Client TLS config (with insecure skip verify for test certificates)
+	clientTLSConfig := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	c, err := tq.NewClient(tq.SetClientTLSDialer("tcp6", listener.Addr().String(), clientTLSConfig))
+	assert.NoError(b, err)
+	defer c.Close()
+
+	test := ASCIILoginFullFlow()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		for _, s := range test.Seq {
+			c.Send(s.Packet)
+		}
+	}
+}
+
+// BenchmarkPacketExchangeAsciiLoginUsingNewClientTLS will test the full ascii login flow
+// using a new TLS client instance each loop
+func BenchmarkPacketExchangeAsciiLoginUsingNewClientTLS(b *testing.B) {
+	testDir := b.TempDir()
+	_, _, serverTLSConfig, err := GenerateTLSCertificate(testDir)
+	assert.NoError(b, err)
+
+	logger := log.New(0, io.Discard) // no logs
+	ctx := context.Background()
+	sp, err := MockSecretProvider(ctx, logger, "testdata/test_config.yaml")
+	assert.NoError(b, err)
+
+	// Create TLS listener
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	assert.NoError(b, err)
+	tlsListener, err := tq.NewTLSListener(listener, serverTLSConfig)
+	assert.NoError(b, err)
+
+	s := tq.NewServer(logger, sp, tq.SetUseTLS(true))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		if err := s.Serve(ctx, tlsListener); err != nil {
+			assert.NoError(b, err)
+		}
+	}()
+
+	// Client TLS config (with insecure skip verify for test certificates)
+	clientTLSConfig := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	test := ASCIILoginFullFlow()
+	for n := 0; n < b.N; n++ {
+		c, err := tq.NewClient(tq.SetClientTLSDialer("tcp6", listener.Addr().String(), clientTLSConfig))
+		assert.NoError(b, err)
+		for _, s := range test.Seq {
+			c.Send(s.Packet)
+		}
+		c.Close()
+	}
+}

--- a/cmds/server/test/server_tls_optimized_bench_test.go
+++ b/cmds/server/test/server_tls_optimized_bench_test.go
@@ -1,0 +1,329 @@
+/*
+ Copyright (c) Facebook, Inc. and its affiliates.
+
+ This source code is licensed under the MIT license found in the
+ LICENSE file in the root directory of this source tree.
+*/
+
+package test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tq "github.com/facebookincubator/tacquito"
+	"github.com/facebookincubator/tacquito/cmds/server/log"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// generateOptimizedTLSCertificate generates the TLS config that is performance focused
+// and makes the tradeoff of security for performance
+func generateOptimizedTLSCertificate(testDir string) (certFile, keyFile string, tlsConfig *tls.Config, err error) {
+	// Use ECDSA P-256 (fastest secure curve)
+	// ref: https://www.ssl.com/article/comparing-ecdsa-vs-rsa-a-simple-guide/
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	// Absolute minimal certificate for maximum parsing speed
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization:  []string{"Test Corp"},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"Test City"},
+			StreetAddress: []string{""},
+			PostalCode:    []string{""},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour), // Very short validity
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.ParseIP("::1")},
+	}
+
+	// Create certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	// Write certificate to file
+	certFile = filepath.Join(testDir, "cert.pem")
+	certOut, err := os.Create(certFile)
+	if err != nil {
+		return "", "", nil, err
+	}
+	defer certOut.Close()
+
+	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	// Write private key to file
+	keyFile = filepath.Join(testDir, "key.pem")
+	keyOut, err := os.Create(keyFile)
+	if err != nil {
+		return "", "", nil, err
+	}
+	defer keyOut.Close()
+
+	privKeyBytes, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	err = pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privKeyBytes})
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	// Load certificate and create ultra-fast TLS config
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	tlsConfig = &tls.Config{
+		Certificates: []tls.Certificate{cert},
+
+		// Performance optimizations targeting the CPU profile bottlenecks:
+		MinVersion: tls.VersionTLS13,
+		MaxVersion: tls.VersionTLS13,
+
+		// Force fastest cipher suite to avoid ML-KEM overhead
+		CipherSuites: []uint16{
+			tls.TLS_AES_128_GCM_SHA256, // Fastest: AES-128-GCM with SHA256
+		},
+
+		InsecureSkipVerify:          true,                               // Skip cert verification
+		SessionTicketsDisabled:      false,                              // Enable session tickets
+		ClientSessionCache:          tls.NewLRUClientSessionCache(1000), // Large session cache
+		DynamicRecordSizingDisabled: true,                               // Fixed record sizes
+
+		// Disable all unnecessary features
+		// ALPN is a TLS extension that allows clients to negotiate the use of a specific application protocol
+		// No ALPN because client and server are both tacacs here with a well known version
+		// no need for any negotiation code
+		NextProtos: nil,
+		ServerName: "", // No SNI
+		// tls.RenegotiateNever disables TLS renegotiation which that allows either the client or server to initiate a new handshake over an existing TLS connection to
+		// change connection parameters
+		// Disabled purely for performance reasons
+		Renegotiation: tls.RenegotiateNever, // Never renegotiate
+		KeyLogWriter:  nil,                  // No key logging
+	}
+
+	return certFile, keyFile, tlsConfig, nil
+}
+
+// BenchmarkUltraFastTLS tests TLS with maximum performance optimizations
+// Based on CPU profile analysis showing ML-KEM and syscall overhead
+func BenchmarkPacketExchangeAsciiLoginUsingSharedClientTLSOptimized(b *testing.B) {
+	testDir := b.TempDir()
+	_, _, serverTLSConfig, err := generateOptimizedTLSCertificate(testDir)
+	assert.NoError(b, err)
+
+	logger := log.New(0, io.Discard)
+	ctx := context.Background()
+	sp, err := MockSecretProvider(ctx, logger, "testdata/test_config.yaml")
+	assert.NoError(b, err)
+
+	// Create TLS listener
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	assert.NoError(b, err)
+	tlsListener, err := tq.NewTLSListener(listener, serverTLSConfig)
+	assert.NoError(b, err)
+
+	s := tq.NewServer(logger, sp, tq.SetUseTLS(true))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		if err := s.Serve(ctx, tlsListener); err != nil {
+			assert.NoError(b, err)
+		}
+	}()
+
+	clientTLSConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS13,
+		MaxVersion:         tls.VersionTLS13,
+		InsecureSkipVerify: true,
+
+		// Disable post-quantum crypto (ML-KEM was 8%+ of CPU time)
+		// Force fastest cipher suite only
+		CipherSuites: []uint16{
+			tls.TLS_AES_128_GCM_SHA256, // Fastest authenticated encryption according to benchmarks
+		},
+
+		// Maximize session reuse to avoid handshakes
+		SessionTicketsDisabled: false,
+		ClientSessionCache:     tls.NewLRUClientSessionCache(1000),
+
+		// Disable unnecessary features
+		NextProtos:                  nil,                  // No ALPN
+		ServerName:                  "",                   // No SNI
+		Renegotiation:               tls.RenegotiateNever, // Never renegotiate
+		DynamicRecordSizingDisabled: true,                 // Disable adaptive record sizes
+
+		// Minimize handshake data
+		KeyLogWriter: nil,
+	}
+
+	// Create shared client to leverage session resumption
+	c, err := tq.NewClient(tq.SetClientTLSDialer("tcp6", listener.Addr().String(), clientTLSConfig))
+	assert.NoError(b, err)
+	defer c.Close()
+
+	test := ASCIILoginFullFlow()
+	b.ReportAllocs()
+	b.ResetTimer() // Don't count setup time
+
+	for n := 0; n < b.N; n++ {
+		for _, s := range test.Seq {
+			_, err := c.Send(s.Packet)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+// BenchmarkPureTLSHandshake tests ONLY TLS handshake performance without any application logic
+// This eliminates bcrypt and authentication overhead completely
+func BenchmarkPureTLSHandshakeOptimized(b *testing.B) {
+	testDir := b.TempDir()
+	_, _, serverTLSConfig, err := generateOptimizedTLSCertificate(testDir)
+	assert.NoError(b, err)
+
+	// Start TLS server
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	assert.NoError(b, err)
+	defer listener.Close()
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			// Upgrade to TLS and immediately close - just measure handshake
+			tlsConn := tls.Server(conn, serverTLSConfig)
+			tlsConn.Handshake()
+			tlsConn.Close()
+		}
+	}()
+
+	clientTLSConfig := &tls.Config{
+		MinVersion:                  tls.VersionTLS13,
+		MaxVersion:                  tls.VersionTLS13,
+		InsecureSkipVerify:          true,
+		CipherSuites:                []uint16{tls.TLS_AES_128_GCM_SHA256},
+		SessionTicketsDisabled:      false,
+		ClientSessionCache:          tls.NewLRUClientSessionCache(1000),
+		DynamicRecordSizingDisabled: true,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	// Test pure TLS handshake performance
+	for n := 0; n < b.N; n++ {
+		conn, err := tls.Dial("tcp6", listener.Addr().String(), clientTLSConfig)
+		if err != nil {
+			b.Fatal(err)
+		}
+		conn.Close()
+	}
+}
+
+// BenchmarkPureTLSHandshakeBaseline tests basic TLS handshake with default settings
+func BenchmarkPureTLSHandshakeBaseline(b *testing.B) {
+	testDir := b.TempDir()
+	_, _, serverTLSConfig, err := GenerateTLSCertificate(testDir)
+	assert.NoError(b, err)
+
+	// Start TLS server
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	assert.NoError(b, err)
+	defer listener.Close()
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			// Upgrade to TLS and immediately close
+			tlsConn := tls.Server(conn, serverTLSConfig)
+			tlsConn.Handshake()
+			tlsConn.Close()
+		}
+	}()
+
+	// Basic client TLS config
+	clientTLSConfig := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	// Test basic TLS handshake performance
+	for n := 0; n < b.N; n++ {
+		conn, err := tls.Dial("tcp6", listener.Addr().String(), clientTLSConfig)
+		if err != nil {
+			b.Fatal(err)
+		}
+		conn.Close()
+	}
+}
+
+// BenchmarkPlainTCPConnection tests raw TCP connection for comparison baseline
+func BenchmarkPlainTCPConnectionAgainstTLS(b *testing.B) {
+	// Start plain TCP server
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	assert.NoError(b, err)
+	defer listener.Close()
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	// Test raw TCP connection performance
+	for n := 0; n < b.N; n++ {
+		conn, err := net.Dial("tcp6", listener.Addr().String())
+		if err != nil {
+			b.Fatal(err)
+		}
+		conn.Close()
+	}
+}

--- a/cmds/server/test/smash_test.go
+++ b/cmds/server/test/smash_test.go
@@ -9,10 +9,11 @@ package test
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"io"
 	"math/rand"
 	"net"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -228,8 +229,9 @@ func acctSmasher(sessionID int) Test {
 		},
 	}
 }
+
 func TestSurge(t *testing.T) {
-	logger := log.New(30, os.Stderr)
+	logger := log.New(30, io.Discard)
 	ctx := context.Background()
 	sp, err := MockSecretProvider(ctx, logger, "testdata/test_config.yaml")
 	assert.NoError(t, err)
@@ -262,6 +264,84 @@ func TestSurge(t *testing.T) {
 	queue := make(chan Test, numberOfClients)
 	do := func(ctest <-chan Test, wg *sync.WaitGroup) {
 		c, err := tq.NewClient(tq.SetClientDialer("tcp6", listener.Addr().String(), []byte("fooman")))
+		if err != nil {
+			assert.FailNow(t, fmt.Sprintf("%v", err))
+		}
+		go func() {
+			defer c.Close()
+			max := 1000
+			min := 1
+			ticker := time.NewTicker(time.Duration(rand.Intn(max-min)+min) * time.Millisecond)
+			for ct := range ctest {
+				// artificial delay
+				<-ticker.C
+				for _, s := range ct.Seq {
+					resp, err := c.Send(s.Packet)
+					assert.NoError(t, err)
+					err = s.Validate(resp)
+					assert.NoError(t, err)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < numberOfClients; i++ {
+		wg.Add(1)
+		do(queue, &wg)
+	}
+	for _, ctest := range tests {
+		queue <- ctest
+	}
+	close(queue)
+	wg.Wait()
+}
+
+func TestSurgeTLS(t *testing.T) {
+	testDir := t.TempDir()
+	_, _, serverTLSConfig, err := GenerateTLSCertificate(testDir)
+	assert.NoError(t, err)
+
+	logger := log.New(30, io.Discard)
+	ctx := context.Background()
+	sp, err := MockSecretProvider(ctx, logger, "testdata/test_config.yaml")
+	assert.NoError(t, err)
+
+	// Create TLS listener
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	assert.NoError(t, err)
+	tlsListener, err := tq.NewTLSListener(listener, serverTLSConfig)
+	assert.NoError(t, err)
+
+	s := tq.NewServer(logger, sp, tq.SetUseTLS(true))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		if err := s.Serve(ctx, tlsListener); err != nil {
+			assert.NoError(t, err)
+		}
+	}()
+
+	// Client TLS config (with insecure skip verify for test certificates)
+	clientTLSConfig := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	// number of sessions to create
+	maxSession := 1500
+	// use a map to randomize session entry
+	tests := map[int]Test{}
+	for i := 1; i <= maxSession; i += 3 {
+		tests[i] = asciiSmasher(i)
+		tests[i+1] = authorSmasher(i + 1)
+		tests[i+2] = acctSmasher(i + 2)
+	}
+
+	// number of clients to create
+	numberOfClients := 75
+	queue := make(chan Test, numberOfClients)
+	do := func(ctest <-chan Test, wg *sync.WaitGroup) {
+		c, err := tq.NewClient(tq.SetClientTLSDialer("tcp6", listener.Addr().String(), clientTLSConfig))
 		if err != nil {
 			assert.FailNow(t, fmt.Sprintf("%v", err))
 		}

--- a/crypt.go
+++ b/crypt.go
@@ -142,7 +142,7 @@ func (c *crypter) read() (*Packet, error) {
 	// read the length field from the bytes of the header to know how many more bytes we need to get
 	s := int(binary.BigEndian.Uint32(h[8:]))
 	if s > int(MaxBodyLength) {
-		return nil, fmt.Errorf("max header length exceeded in crypt read, aborting")
+		return nil, fmt.Errorf("max header length exceeded in crypt read, aborting. tls enabled: [%t]", c.tls)
 	}
 	b := make([]byte, s)
 	if _, err := io.ReadFull(c.Reader, b); err != nil {
@@ -184,6 +184,7 @@ func (c *crypter) read() (*Packet, error) {
 			TACACS+ message type, with the TAC_PLUS_UNENCRYPTED_FLAG bit set to 1, and terminate the session
 		*/
 		if !p.Header.Flags.Has(UnencryptedFlag) {
+			crypterReadFlagError.Inc()
 			reply, err := c.unsetFlagReply(p.Header)
 			if err != nil {
 				return nil, err

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -8,12 +8,56 @@
 package tacquito
 
 import (
+	"bufio"
+	"encoding/binary"
 	"fmt"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 )
+
+// mockConnection is a mock implementation of net.Conn for testing
+type mockConnection struct {
+	data   []byte
+	closed bool
+}
+
+func (m *mockConnection) Read(b []byte) (n int, err error) {
+	if len(m.data) == 0 {
+		return 0, fmt.Errorf("no data")
+	}
+	n = copy(b, m.data)
+	m.data = m.data[n:]
+	return n, nil
+}
+
+func (m *mockConnection) Write(b []byte) (n int, err error) {
+	if m.closed {
+		return 0, fmt.Errorf("connection closed")
+	}
+	m.data = append(m.data, b...)
+	return len(b), nil
+}
+
+func (m *mockConnection) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *mockConnection) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 49}
+}
+
+func (m *mockConnection) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}
+}
+
+func (m *mockConnection) SetDeadline(t time.Time) error      { return nil }
+func (m *mockConnection) SetReadDeadline(t time.Time) error  { return nil }
+func (m *mockConnection) SetWriteDeadline(t time.Time) error { return nil }
 
 // returns an encrypted TACACs+ packet's byte values, contains the 12 byte header
 // encrypted with secret []byte("fooman")
@@ -190,4 +234,705 @@ func BenchmarkCrypterAllocation(b *testing.B) {
 	for range b.N {
 		crypt(secret, packet)
 	}
+}
+
+// TestUnsetFlagReplyAuthenticate tests the unsetFlagReply function for authentication packets
+func TestUnsetFlagReplyAuthenticate(t *testing.T) {
+	c := &crypter{tls: true}
+	header := NewHeader(
+		SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+		SetHeaderType(Authenticate),
+		SetHeaderSessionID(12345),
+		SetHeaderSeqNo(5),
+	)
+
+	reply, err := c.unsetFlagReply(header)
+	assert.NoError(t, err)
+	assert.NotNil(t, reply)
+
+	// Verify the header flags and sequence number have been properly set
+	assert.True(t, reply.Header.Flags.Has(UnencryptedFlag))
+	assert.Equal(t, SequenceNumber(1), reply.Header.SeqNo)
+
+	// Verify the body contains the expected error response
+	var authenReply AuthenReply
+	err = Unmarshal(reply.Body, &authenReply)
+	assert.NoError(t, err)
+	assert.Equal(t, AuthenStatusError, authenReply.Status)
+	assert.Equal(t, AuthenServerMsg("unencrypted flag not set"), authenReply.ServerMsg)
+}
+
+// TestUnsetFlagReplyAuthorize tests the unsetFlagReply function for authorization packets
+func TestUnsetFlagReplyAuthorize(t *testing.T) {
+	c := &crypter{tls: true}
+	header := NewHeader(
+		SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+		SetHeaderType(Authorize),
+		SetHeaderSessionID(12345),
+		SetHeaderSeqNo(5),
+	)
+
+	reply, err := c.unsetFlagReply(header)
+	assert.NoError(t, err)
+	assert.NotNil(t, reply)
+
+	// Verify the header flags and sequence number have been properly set
+	assert.True(t, reply.Header.Flags.Has(UnencryptedFlag))
+	assert.Equal(t, SequenceNumber(1), reply.Header.SeqNo)
+
+	// Verify the body contains the expected error response
+	var authorReply AuthorReply
+	err = Unmarshal(reply.Body, &authorReply)
+	assert.NoError(t, err)
+	assert.Equal(t, AuthorStatusError, authorReply.Status)
+	assert.Equal(t, AuthorServerMsg("unencrypted flag not set"), authorReply.ServerMsg)
+}
+
+// TestUnsetFlagReplyAccounting tests the unsetFlagReply function for accounting packets
+func TestUnsetFlagReplyAccounting(t *testing.T) {
+	c := &crypter{tls: true}
+	header := NewHeader(
+		SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+		SetHeaderType(Accounting),
+		SetHeaderSessionID(12345),
+		SetHeaderSeqNo(5),
+	)
+
+	reply, err := c.unsetFlagReply(header)
+	assert.NoError(t, err)
+	assert.NotNil(t, reply)
+
+	// Verify the header flags and sequence number have been properly set
+	assert.True(t, reply.Header.Flags.Has(UnencryptedFlag))
+	assert.Equal(t, SequenceNumber(1), reply.Header.SeqNo)
+
+	// Verify the body contains the expected error response
+	var acctReply AcctReply
+	err = Unmarshal(reply.Body, &acctReply)
+	assert.NoError(t, err)
+	assert.Equal(t, AcctReplyStatusError, acctReply.Status)
+	assert.Equal(t, AcctServerMsg("unencrypted flag not set"), acctReply.ServerMsg)
+}
+
+// TestUnsetFlagReplyInvalidType tests the unsetFlagReply function with an invalid header type
+func TestUnsetFlagReplyInvalidType(t *testing.T) {
+	c := &crypter{tls: true}
+	header := NewHeader(
+		SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+		SetHeaderType(HeaderType(99)), // Invalid type
+		SetHeaderSessionID(12345),
+	)
+
+	reply, err := c.unsetFlagReply(header)
+	assert.Error(t, err)
+	assert.Nil(t, reply)
+	assert.Contains(t, err.Error(), "unknown header type")
+}
+
+// TestBadSecretReplyAuthenticate tests the badSecretReply function for authentication packets
+func TestBadSecretReplyAuthenticate(t *testing.T) {
+	c := &crypter{}
+	header := NewHeader(
+		SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+		SetHeaderType(Authenticate),
+		SetHeaderSessionID(12345),
+		SetHeaderSeqNo(5),
+	)
+
+	reply, err := c.badSecretReply(header)
+	assert.NoError(t, err)
+	assert.NotNil(t, reply)
+
+	// Verify the sequence number has been reset
+	assert.Equal(t, SequenceNumber(1), reply.Header.SeqNo)
+
+	// Verify the body contains the expected error response
+	var authenReply AuthenReply
+	err = Unmarshal(reply.Body, &authenReply)
+	assert.NoError(t, err)
+	assert.Equal(t, AuthenStatusError, authenReply.Status)
+	assert.Equal(t, AuthenServerMsg("bad secret"), authenReply.ServerMsg)
+}
+
+// TestBadSecretReplyAuthorize tests the badSecretReply function for authorization packets
+func TestBadSecretReplyAuthorize(t *testing.T) {
+	c := &crypter{}
+	header := NewHeader(
+		SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+		SetHeaderType(Authorize),
+		SetHeaderSessionID(12345),
+		SetHeaderSeqNo(5),
+	)
+
+	reply, err := c.badSecretReply(header)
+	assert.NoError(t, err)
+	assert.NotNil(t, reply)
+
+	// Verify the sequence number has been reset
+	assert.Equal(t, SequenceNumber(1), reply.Header.SeqNo)
+
+	// Verify the body contains the expected error response
+	var authorReply AuthorReply
+	err = Unmarshal(reply.Body, &authorReply)
+	assert.NoError(t, err)
+	assert.Equal(t, AuthorStatusError, authorReply.Status)
+	assert.Equal(t, AuthorServerMsg("bad secret"), authorReply.ServerMsg)
+}
+
+// TestBadSecretReplyAccounting tests the badSecretReply function for accounting packets
+func TestBadSecretReplyAccounting(t *testing.T) {
+	c := &crypter{}
+	header := NewHeader(
+		SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+		SetHeaderType(Accounting),
+		SetHeaderSessionID(12345),
+		SetHeaderSeqNo(5),
+	)
+
+	reply, err := c.badSecretReply(header)
+	assert.NoError(t, err)
+	assert.NotNil(t, reply)
+
+	// Verify the sequence number has been reset
+	assert.Equal(t, SequenceNumber(1), reply.Header.SeqNo)
+
+	// Verify the body contains the expected error response
+	var acctReply AcctReply
+	err = Unmarshal(reply.Body, &acctReply)
+	assert.NoError(t, err)
+	assert.Equal(t, AcctReplyStatusError, acctReply.Status)
+	assert.Equal(t, AcctServerMsg("bad secret"), acctReply.ServerMsg)
+}
+
+// TestBadSecretReplyInvalidType tests the badSecretReply function with an invalid header type
+func TestBadSecretReplyInvalidType(t *testing.T) {
+	c := &crypter{}
+	header := NewHeader(
+		SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+		SetHeaderType(HeaderType(99)), // Invalid type
+		SetHeaderSessionID(12345),
+	)
+
+	reply, err := c.badSecretReply(header)
+	assert.Error(t, err)
+	assert.Nil(t, reply)
+	assert.Contains(t, err.Error(), "unknown header type")
+}
+
+// TestNewCrypterWithTLS tests creating a new crypter with TLS enabled
+func TestNewCrypterWithTLS(t *testing.T) {
+	secret := []byte("test-secret")
+	mockConn := &mockConnection{}
+
+	// Test creating crypter without TLS
+	c := newCrypter(secret, mockConn, false, false)
+	assert.Equal(t, secret, c.secret)
+	assert.Equal(t, mockConn, c.Conn)
+	assert.False(t, c.proxy)
+	assert.False(t, c.tls)
+
+	// Test creating crypter with proxy enabled
+	c = newCrypter(secret, mockConn, false, true)
+	assert.True(t, c.tls)
+	assert.False(t, c.proxy)
+}
+
+// TestCrypterWriteTLS tests the write method behavior with TLS enabled
+func TestCrypterWriteTLS(t *testing.T) {
+	mockConn := &mockConnection{}
+	c := &crypter{
+		secret: []byte("test-secret"),
+		Conn:   mockConn,
+		tls:    true,
+	}
+
+	body := NewAuthenReply(
+		SetAuthenReplyStatus(AuthenStatusGetUser),
+		SetAuthenReplyServerMsg("Username:"),
+	)
+	b, _ := body.MarshalBinary()
+
+	packet := NewPacket(
+		SetPacketHeader(
+			NewHeader(
+				SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+				SetHeaderType(Authenticate),
+				SetHeaderSessionID(12345),
+			),
+		),
+		SetPacketBody(b),
+	)
+
+	// Initially, the packet should not have the UnencryptedFlag set
+	assert.False(t, packet.Header.Flags.Has(UnencryptedFlag))
+
+	n, err := c.write(packet)
+	assert.NoError(t, err)
+	assert.Greater(t, n, 0)
+
+	// After write with TLS enabled, the UnencryptedFlag should be set
+	assert.True(t, packet.Header.Flags.Has(UnencryptedFlag))
+}
+
+// TestCrypterWriteNonTLS tests the write method behavior with TLS disabled
+func TestCrypterWriteNonTLS(t *testing.T) {
+	mockConn := &mockConnection{}
+	c := &crypter{
+		secret: []byte("test-secret"),
+		Conn:   mockConn,
+		tls:    false,
+	}
+
+	body := NewAuthenReply(
+		SetAuthenReplyStatus(AuthenStatusGetUser),
+		SetAuthenReplyServerMsg("Username:"),
+	)
+	b, _ := body.MarshalBinary()
+
+	packet := NewPacket(
+		SetPacketHeader(
+			NewHeader(
+				SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+				SetHeaderType(Authenticate),
+				SetHeaderSessionID(12345),
+			),
+		),
+		SetPacketBody(b),
+	)
+
+	// Store original body for comparison
+	originalBody := make([]byte, len(packet.Body))
+	copy(originalBody, packet.Body)
+
+	n, err := c.write(packet)
+	assert.NoError(t, err)
+	assert.Greater(t, n, 0)
+
+	// For non-TLS connections, the body should be encrypted (different from original)
+	assert.NotEqual(t, originalBody, packet.Body)
+	// UnencryptedFlag should not be set
+	assert.False(t, packet.Header.Flags.Has(UnencryptedFlag))
+}
+
+// TestCrypterWriteNilPacket tests the write method with nil packet
+func TestCrypterWriteNilPacket(t *testing.T) {
+	mockConn := &mockConnection{}
+	c := &crypter{
+		secret: []byte("test-secret"),
+		Conn:   mockConn,
+		tls:    false,
+	}
+
+	n, err := c.write(nil)
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+	assert.Contains(t, err.Error(), "packet cannot be nil")
+}
+
+// TestCrypterWriteNilBody tests the write method with nil packet body
+func TestCrypterWriteNilBody(t *testing.T) {
+	mockConn := &mockConnection{}
+	c := &crypter{
+		secret: []byte("test-secret"),
+		Conn:   mockConn,
+		tls:    false,
+	}
+
+	packet := NewPacket(
+		SetPacketHeader(
+			NewHeader(
+				SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+				SetHeaderType(Authenticate),
+				SetHeaderSessionID(12345),
+			),
+		),
+		SetPacketBody(nil),
+	)
+
+	n, err := c.write(packet)
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+	assert.Contains(t, err.Error(), "packet.Body cannot be nil")
+}
+
+// TestCrypterReadTLSWithUnencryptedFlag tests the read method with TLS enabled and UnencryptedFlag set
+func TestCrypterReadTLSWithUnencryptedFlag(t *testing.T) {
+	// Create a valid TACACS+ packet with UnencryptedFlag set
+	body := NewAuthenStart(
+		SetAuthenStartAction(AuthenActionLogin),
+		SetAuthenStartPrivLvl(PrivLvlUser),
+		SetAuthenStartType(AuthenTypeASCII),
+		SetAuthenStartService(AuthenServiceLogin),
+		SetAuthenStartUser("admin"),
+		SetAuthenStartPort("command-api"),
+		SetAuthenStartRemAddr("127.0.0.1"),
+	)
+	b, _ := body.MarshalBinary()
+
+	packet := NewPacket(
+		SetPacketHeader(
+			NewHeader(
+				SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+				SetHeaderType(Authenticate),
+				SetHeaderFlag(UnencryptedFlag), // Set the flag for TLS
+				SetHeaderSessionID(12345),
+			),
+		),
+		SetPacketBody(b),
+	)
+
+	// Marshal the entire packet to bytes
+	packetBytes, err := packet.MarshalBinary()
+	assert.NoError(t, err)
+
+	// Create mock connection with the packet data
+	mockConn := &mockConnection{data: packetBytes}
+	c := &crypter{
+		secret: []byte("test-secret"),
+		Conn:   mockConn,
+		Reader: bufio.NewReader(mockConn),
+		tls:    true,
+	}
+
+	// Read the packet
+	readPacket, err := c.read()
+	assert.NoError(t, err)
+	assert.NotNil(t, readPacket)
+
+	// Verify the packet was read correctly
+	assert.Equal(t, Authenticate, readPacket.Header.Type)
+	assert.True(t, readPacket.Header.Flags.Has(UnencryptedFlag))
+	assert.Equal(t, SessionID(12345), readPacket.Header.SessionID)
+
+	// Verify the body can be unmarshaled correctly
+	var readBody AuthenStart
+	err = Unmarshal(readPacket.Body, &readBody)
+	assert.NoError(t, err)
+	assert.Equal(t, AuthenUser("admin"), readBody.User)
+}
+
+// TestCrypterReadTLSWithoutUnencryptedFlag tests the read method with TLS enabled but UnencryptedFlag not set
+func TestCrypterReadTLSWithoutUnencryptedFlag(t *testing.T) {
+	// Create a valid TACACS+ packet WITHOUT UnencryptedFlag set
+	body := NewAuthenStart(
+		SetAuthenStartAction(AuthenActionLogin),
+		SetAuthenStartPrivLvl(PrivLvlUser),
+		SetAuthenStartType(AuthenTypeASCII),
+		SetAuthenStartService(AuthenServiceLogin),
+		SetAuthenStartUser("admin"),
+		SetAuthenStartPort("command-api"),
+		SetAuthenStartRemAddr("127.0.0.1"),
+	)
+	b, _ := body.MarshalBinary()
+
+	packet := NewPacket(
+		SetPacketHeader(
+			NewHeader(
+				SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+				SetHeaderType(Authenticate),
+				// UnencryptedFlag is NOT set - this should trigger an error response
+				SetHeaderSessionID(12345),
+			),
+		),
+		SetPacketBody(b),
+	)
+
+	// Marshal the entire packet to bytes
+	packetBytes, err := packet.MarshalBinary()
+	assert.NoError(t, err)
+
+	// Create mock connection with the packet data
+	mockConn := &mockConnection{data: packetBytes}
+	c := &crypter{
+		secret: []byte("test-secret"),
+		Conn:   mockConn,
+		Reader: bufio.NewReader(mockConn),
+		tls:    true,
+	}
+
+	// Read the packet - this should trigger the unset flag reply mechanism
+	readPacket, err := c.read()
+	assert.NoError(t, err)
+	assert.NotNil(t, readPacket)
+
+	// Verify that an error response was written to the connection
+	// The mockConnection should now have the error response in its data
+	assert.Greater(t, len(mockConn.data), 0, "Expected error response to be written to connection")
+}
+
+// TestCrypterReadNonTLSEncrypted tests the read method with TLS disabled and encrypted packet
+func TestCrypterReadNonTLSEncrypted(t *testing.T) {
+	// Use the pre-existing encrypted test data
+	encryptedBytes := getEncryptedBytes()
+
+	// Create mock connection with encrypted packet data
+	mockConn := &mockConnection{data: encryptedBytes}
+	c := &crypter{
+		secret: []byte("fooman"), // Use the matching secret for test data
+		Conn:   mockConn,
+		Reader: bufio.NewReader(mockConn),
+		tls:    false,
+	}
+
+	// Read the packet
+	readPacket, err := c.read()
+	assert.NoError(t, err)
+	assert.NotNil(t, readPacket)
+
+	// Verify the packet was decrypted correctly
+	assert.Equal(t, Authenticate, readPacket.Header.Type)
+	assert.False(t, readPacket.Header.Flags.Has(UnencryptedFlag))
+	assert.Equal(t, SessionID(12345), readPacket.Header.SessionID)
+
+	// Verify the body was decrypted and can be unmarshaled correctly
+	var readBody AuthenStart
+	err = Unmarshal(readPacket.Body, &readBody)
+	assert.NoError(t, err)
+	assert.Equal(t, AuthenUser("admin"), readBody.User)
+	assert.Equal(t, AuthenPort("command-api"), readBody.Port)
+}
+
+// TestCrypterReadNonTLSBadSecret tests the read method with TLS disabled and bad secret
+func TestCrypterReadNonTLSBadSecret(t *testing.T) {
+	// Use the pre-existing encrypted test data
+	encryptedBytes := getEncryptedBytes()
+
+	// Create mock connection with encrypted packet data
+	mockConn := &mockConnection{data: encryptedBytes}
+	c := &crypter{
+		secret: []byte("bad-secret"), // Use wrong secret to trigger bad secret detection
+		Conn:   mockConn,
+		Reader: bufio.NewReader(mockConn),
+		tls:    false,
+	}
+
+	// Read the packet - this should trigger bad secret detection
+	readPacket, err := c.read()
+	assert.Error(t, err)
+	assert.Nil(t, readPacket)
+	assert.Contains(t, err.Error(), "bad secret detected")
+
+	// Verify that an error response was written to the connection
+	assert.Greater(t, len(mockConn.data), 0, "Expected bad secret response to be written to connection")
+}
+
+// TestCrypterReadNonTLSUnencrypted tests the read method with TLS disabled and unencrypted packet
+func TestCrypterReadNonTLSUnencrypted(t *testing.T) {
+	// Create a valid TACACS+ packet with UnencryptedFlag set (for non-TLS)
+	body := NewAuthenStart(
+		SetAuthenStartAction(AuthenActionLogin),
+		SetAuthenStartPrivLvl(PrivLvlUser),
+		SetAuthenStartType(AuthenTypeASCII),
+		SetAuthenStartService(AuthenServiceLogin),
+		SetAuthenStartUser("admin"),
+		SetAuthenStartPort("command-api"),
+		SetAuthenStartRemAddr("127.0.0.1"),
+	)
+	b, _ := body.MarshalBinary()
+
+	packet := NewPacket(
+		SetPacketHeader(
+			NewHeader(
+				SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+				SetHeaderType(Authenticate),
+				SetHeaderFlag(UnencryptedFlag), // Packet is unencrypted
+				SetHeaderSessionID(12345),
+			),
+		),
+		SetPacketBody(b),
+	)
+
+	// Marshal the entire packet to bytes
+	packetBytes, err := packet.MarshalBinary()
+	assert.NoError(t, err)
+
+	// Create mock connection with the packet data
+	mockConn := &mockConnection{data: packetBytes}
+	c := &crypter{
+		secret: []byte("test-secret"),
+		Conn:   mockConn,
+		Reader: bufio.NewReader(mockConn),
+		tls:    false,
+	}
+
+	// Read the packet
+	readPacket, err := c.read()
+	assert.NoError(t, err)
+	assert.NotNil(t, readPacket)
+
+	// Verify the packet was read correctly (no decryption needed)
+	assert.Equal(t, Authenticate, readPacket.Header.Type)
+	assert.True(t, readPacket.Header.Flags.Has(UnencryptedFlag))
+	assert.Equal(t, SessionID(12345), readPacket.Header.SessionID)
+
+	// Verify the body can be unmarshaled correctly
+	var readBody AuthenStart
+	err = Unmarshal(readPacket.Body, &readBody)
+	assert.NoError(t, err)
+	assert.Equal(t, AuthenUser("admin"), readBody.User)
+}
+
+// TestCrypterReadProxyHeader tests the read method with proxy header enabled
+func TestCrypterReadProxyHeader(t *testing.T) {
+	// Create a valid TACACS+ packet
+	body := NewAuthenStart(
+		SetAuthenStartAction(AuthenActionLogin),
+		SetAuthenStartPrivLvl(PrivLvlUser),
+		SetAuthenStartType(AuthenTypeASCII),
+		SetAuthenStartService(AuthenServiceLogin),
+		SetAuthenStartUser("admin"),
+		SetAuthenStartPort("command-api"),
+		SetAuthenStartRemAddr("127.0.0.1"),
+	)
+	b, _ := body.MarshalBinary()
+
+	packet := NewPacket(
+		SetPacketHeader(
+			NewHeader(
+				SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+				SetHeaderType(Authenticate),
+				SetHeaderFlag(UnencryptedFlag),
+				SetHeaderSessionID(12345),
+			),
+		),
+		SetPacketBody(b),
+	)
+
+	// Marshal the entire packet to bytes
+	packetBytes, err := packet.MarshalBinary()
+	assert.NoError(t, err)
+
+	// Prepend a proxy header (null-terminated string)
+	proxyHeader := "PROXY TCP4 192.168.1.1 192.168.1.2 12345 49\000"
+	dataWithProxy := append([]byte(proxyHeader), packetBytes...)
+
+	// Create mock connection with proxy header + packet data
+	mockConn := &mockConnection{data: dataWithProxy}
+	c := &crypter{
+		secret: []byte("test-secret"),
+		Conn:   mockConn,
+		Reader: bufio.NewReader(mockConn),
+		proxy:  true, // Enable proxy header processing
+		tls:    true,
+	}
+
+	// Read the packet
+	readPacket, err := c.read()
+	assert.NoError(t, err)
+	assert.NotNil(t, readPacket)
+
+	// Verify the packet was read correctly after stripping proxy header
+	assert.Equal(t, Authenticate, readPacket.Header.Type)
+	assert.True(t, readPacket.Header.Flags.Has(UnencryptedFlag))
+	assert.Equal(t, SessionID(12345), readPacket.Header.SessionID)
+}
+
+// TestCrypterReadInvalidPacketSize tests the read method with packet exceeding max body length
+func TestCrypterReadInvalidPacketSize(t *testing.T) {
+	// Create a valid header first
+	header := NewHeader(
+		SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+		SetHeaderType(Authenticate),
+		SetHeaderSessionID(12345),
+	)
+	header.Length = 100 // Set to a valid length initially
+
+	headerBytes, err := header.MarshalBinary()
+	assert.NoError(t, err)
+
+	// Now manually modify the length field in the raw bytes to exceed MaxBodyLength
+	// The length field is at bytes 8-11 (big endian uint32)
+	binary.BigEndian.PutUint32(headerBytes[8:12], MaxBodyLength+1)
+
+	// Create mock connection with the modified header
+	mockConn := &mockConnection{data: headerBytes}
+	c := &crypter{
+		secret: []byte("test-secret"),
+		Conn:   mockConn,
+		Reader: bufio.NewReader(mockConn),
+		tls:    false,
+	}
+
+	// Read the packet - should fail due to exceeding max length
+	readPacket, err := c.read()
+	assert.Error(t, err)
+	assert.Nil(t, readPacket)
+	assert.Contains(t, err.Error(), "max header length exceeded")
+}
+
+// TestCrypterReadTLSReturnsCorrectPacket tests that TLS read returns the unmodified packet
+func TestCrypterReadTLSReturnsCorrectPacket(t *testing.T) {
+	// Create expected packet data
+	body := NewAuthenStart(
+		SetAuthenStartAction(AuthenActionLogin),
+		SetAuthenStartPrivLvl(PrivLvlUser),
+		SetAuthenStartType(AuthenTypeASCII),
+		SetAuthenStartService(AuthenServiceLogin),
+		SetAuthenStartUser("testuser"),
+		SetAuthenStartPort("tty1"),
+		SetAuthenStartRemAddr("10.0.0.1"),
+	)
+	b, _ := body.MarshalBinary()
+
+	packet := NewPacket(
+		SetPacketHeader(
+			NewHeader(
+				SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionOne}),
+				SetHeaderType(Authenticate),
+				SetHeaderFlag(UnencryptedFlag),
+				SetHeaderSessionID(54321),
+				SetHeaderSeqNo(2),
+			),
+		),
+		SetPacketBody(b),
+	)
+
+	// Marshal packet to bytes
+	data, err := packet.MarshalBinary()
+	assert.NoError(t, err)
+
+	// Create mock connection
+	mockConn := &mockConnection{data: data}
+	c := &crypter{
+		secret: []byte("test-secret"),
+		Conn:   mockConn,
+		Reader: bufio.NewReader(mockConn),
+		tls:    true,
+	}
+
+	// Read packet
+	readPacket, err := c.read()
+	assert.NoError(t, err)
+	assert.NotNil(t, readPacket)
+
+	// Verify packet is returned unmodified (since TLS skips obfuscation)
+	assert.Equal(t, packet.Header.Type, readPacket.Header.Type)
+	assert.Equal(t, packet.Header.SessionID, readPacket.Header.SessionID)
+	assert.Equal(t, packet.Header.SeqNo, readPacket.Header.SeqNo)
+	assert.True(t, readPacket.Header.Flags.Has(UnencryptedFlag))
+
+	// Verify body content
+	var readBody AuthenStart
+	err = Unmarshal(readPacket.Body, &readBody)
+	assert.NoError(t, err)
+	assert.Equal(t, AuthenUser("testuser"), readBody.User)
+	assert.Equal(t, AuthenPort("tty1"), readBody.Port)
+	assert.Equal(t, AuthenRemAddr("10.0.0.1"), readBody.RemAddr)
+}
+
+// TestDetectBadSecretWithUnencryptedFlag tests that detectBadSecret returns nil for unencrypted packets
+func TestDetectBadSecretWithUnencryptedFlag(t *testing.T) {
+	c := &crypter{}
+
+	packet := &Packet{
+		Header: NewHeader(
+			SetHeaderType(Authenticate),
+			SetHeaderFlag(UnencryptedFlag),
+		),
+		Body: []byte("test body"),
+	}
+
+	reply, err := c.detectBadSecret(packet)
+	assert.NoError(t, err)
+	assert.Nil(t, reply)
 }

--- a/docs/tls_support.md
+++ b/docs/tls_support.md
@@ -27,7 +27,7 @@ The following command-line options have been added to the server to support TLS:
 When using TLS, IANA recommends a different port (tacacss) for TACACS+ over TLS.
 
 ```
-  -address ":49"              Standard TACACS+ port (works with TLS)
+  -address ":49"              Standard TACACS+ port
   -address ":XXXX"            Alternative TACACS+ port (tacacss:300)
                               In this document, we will use port 6653 for testing
 ```
@@ -192,13 +192,6 @@ openssl verify -CAfile ca.crt client.crt
 ```bash
 ./client -tls -username cisco -address "localhost:6653" \
   -tls-ca ca.crt -tls-cert client.crt -tls-key client.key
-```
-
-### TLS Client with Server Name Verification
-
-```bash
-./client -tls -username cisco -address "localhost:6653" -secret "shared_secret" \
-  -tls-ca ca.crt -tls-server-name "localhost"
 ```
 
 ### TLS Client with Insecure Skip Verify (Testing Only)
@@ -398,17 +391,6 @@ execute pap authentication
 2. TACACS+ protocol layer has issues
 3. Check that client sends unencrypted packets within TLS tunnel
 4. Verify server expects unencrypted packets for TLS connections
-
-### 9. Step-by-Step Debugging Workflow
-
-When facing TLS issues, follow this systematic approach:
-
-1. **Start with certificate verification** - Use `openssl verify` and `openssl x509 -text`
-2. **Test basic TLS handshake** - Use `openssl s_client` before trying TACACS+
-3. **Check server logs** - Look for specific error messages
-4. **Test without mutual TLS first** - Verify server certificate validation works
-5. **Add client certificates gradually** - Test mutual TLS only after basic TLS works
-6. **Enable verbose logging** - Add debugging flags to see detailed error messages
 
 ### 10. Useful OpenSSL Commands Reference
 

--- a/docs/tls_support.md
+++ b/docs/tls_support.md
@@ -1,0 +1,450 @@
+# TACACS+ over TLS Support
+
+This document describes the implementation of TACACS+ over TLS as specified in [IETF draft-ietf-opsawg-tacacs-tls13-07](https://www.ietf.org/archive/id/draft-ietf-opsawg-tacacs-tls13-07.html).
+
+## Overview
+
+The TACACS+ protocol traditionally operates over a TCP connection without encryption, relying on a shared secret for packet encryption. This implementation adds support for TACACS+ over TLS 1.3, providing stronger security through:
+
+- Transport layer encryption using TLS 1.3
+- Certificate-based authentication with Subject Alternative Names (SAN)
+- Optional mutual TLS authentication
+
+## Command-line Options
+
+The following command-line options have been added to the server to support TLS:
+
+```
+  -tls                        Enable TLS support as per IETF draft-ietf-opsawg-tacacs-tls13-07
+  -tls-cert string            Path to TLS certificate file
+  -tls-key string             Path to TLS key file
+  -tls-ca string              Path to TLS CA certificate file for client certificate validation
+  -tls-require-client-cert    Require client certificates for TLS connections
+```
+
+## Port Configuration
+
+When using TLS, IANA recommends a different port (tacacss) for TACACS+ over TLS.
+
+```
+  -address ":49"              Standard TACACS+ port (works with TLS)
+  -address ":XXXX"            Alternative TACACS+ port (tacacss:300)
+                              In this document, we will use port 6653 for testing
+```
+
+## Certificate Generation with SAN Extensions
+
+**IMPORTANT**: Modern TLS implementations require certificates with Subject Alternative Names (SAN) extensions. Certificates that rely only on the Common Name (CN) field will fail with errors like:
+
+```
+tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
+```
+
+## Setting up a test environment
+### Generate CA Certificate
+
+```bash
+# Generate CA private key
+openssl genrsa -out ca.key 2048
+
+# Generate CA certificate
+openssl req -x509 -new -nodes -key ca.key -sha256 -days 365 -out ca.crt -subj "/CN=TACACS_Test_CA"
+```
+
+### Generate Server Certificate with SAN Extensions
+
+First, create a configuration file for the server certificate:
+
+```bash
+cat > server.conf << 'EOF'
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+CN = localhost
+
+[v3_req]
+keyUsage = keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+IP.1 = ::1
+IP.2 = 127.0.0.1
+EOF
+```
+
+Then generate the server certificate:
+
+```bash
+# Generate server private key
+openssl genrsa -out server.key 2048
+
+# Generate server certificate signing request (CSR) with SAN configuration
+openssl req -new -key server.key -out server.csr -config server.conf
+
+# Sign the server certificate with SAN extensions
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 365 -sha256 -extensions v3_req -extfile server.conf
+```
+
+### Generate Client Certificate with SAN Extensions (for mutual TLS)
+
+First, create a configuration file for the client certificate:
+
+```bash
+cat > client.conf << 'EOF'
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+CN = localhost
+
+[v3_req]
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+IP.1 = ::1
+IP.2 = 127.0.0.1
+EOF
+```
+
+Then generate the client certificate:
+
+```bash
+# Generate client private key
+openssl genrsa -out client.key 2048
+
+# Generate client certificate signing request (CSR) with SAN configuration
+openssl req -new -key client.key -out client.csr -config client.conf
+
+# Sign the client certificate with SAN extensions
+openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 365 -sha256 -extensions v3_req -extfile client.conf
+```
+
+### Verify Certificate SAN Extensions
+
+You can verify that your certificates include proper SAN extensions:
+
+```bash
+# Verify server certificate SAN extensions
+openssl x509 -in server.crt -text -noout | grep -A 3 "Subject Alternative Name"
+
+# Expected output:
+# X509v3 Subject Alternative Name:
+#     DNS:localhost, IP Address:0:0:0:0:0:0:0:1, IP Address:127.0.0.1
+
+# Verify client certificate SAN extensions
+openssl x509 -in client.crt -text -noout | grep -A 3 "Subject Alternative Name"
+```
+
+### Verify Certificate Chain
+
+Ensure the certificate chain is valid:
+
+```bash
+# Verify server certificate chain
+openssl verify -CAfile ca.crt server.crt
+# Expected: server.crt: OK
+
+# Verify client certificate chain
+openssl verify -CAfile ca.crt client.crt
+# Expected: client.crt: OK
+```
+
+## Running the Server with TLS
+
+### Basic TLS Server (Server Certificate Only)
+
+```bash
+./server -tls -tls-cert server.crt -tls-key server.key -address ":6653"
+```
+
+### TLS Server with Client Certificate Validation
+
+```bash
+./server -tls -tls-cert server.crt -tls-key server.key -tls-ca ca.crt -address ":6653"
+```
+
+### TLS Server Requiring Client Certificates (Mutual TLS)
+
+```bash
+./server -tls -tls-cert server.crt -tls-key server.key -tls-ca ca.crt -tls-require-client-cert -address ":6653"
+```
+
+## Running the Client with TLS
+
+### Basic TLS Client (Server Certificate Validation Only)
+
+```bash
+./client -tls -username cisco -address "localhost:6653" -tls-ca ca.crt
+```
+
+### TLS Client with Client Certificate (Mutual TLS)
+
+```bash
+./client -tls -username cisco -address "localhost:6653" \
+  -tls-ca ca.crt -tls-cert client.crt -tls-key client.key
+```
+
+### TLS Client with Server Name Verification
+
+```bash
+./client -tls -username cisco -address "localhost:6653" -secret "shared_secret" \
+  -tls-ca ca.crt -tls-server-name "localhost"
+```
+
+### TLS Client with Insecure Skip Verify (Testing Only)
+
+```bash
+./client -tls -username cisco -address "localhost:6653" -tls-insecure-skip-verify
+```
+
+**Warning**: Never use `-tls-insecure-skip-verify` in production environments.
+
+## Testing TLS Configuration
+
+### Test Certificate Chain with OpenSSL
+
+```bash
+# Test TLS connection to server
+echo | timeout 5 openssl s_client -connect localhost:6653 -CAfile ca.crt -servername localhost
+
+# Expected output should include:
+# Verification: OK
+# Verify return code: 0 (ok)
+```
+
+### Test Mutual TLS with OpenSSL
+
+```bash
+# Test TLS connection with client certificate
+echo | timeout 5 openssl s_client -connect localhost:6653 -CAfile ca.crt \
+  -cert client.crt -key client.key -servername localhost
+```
+
+## Implementation Details
+
+The TLS implementation follows these key principles:
+
+1. **TLS Version**: Requires TLS 1.3 as specified in the IETF draft
+2. **Certificate Validation**: Properly validates server and client certificates with SAN extensions
+3. **Packet Processing**: TACACS+ packets are sent unencrypted within the TLS tunnel (with UnencryptedFlag set)
+4. **Backward Compatibility**: The server can still operate in non-TLS mode for backward compatibility
+
+## Debugging TLS Issues
+
+When troubleshooting TACACS+ over TLS problems, follow this systematic debugging approach:
+
+### 1. Verify Certificate Chain
+
+First, ensure all certificates are properly generated and linked:
+
+```bash
+# Verify server certificate chain
+openssl verify -CAfile ca.crt server.crt
+# Expected: server.crt: OK
+
+# Verify client certificate chain
+openssl verify -CAfile ca.crt client.crt
+# Expected: client.crt: OK
+```
+
+### 2. Check Certificate SAN Extensions
+
+Modern TLS requires Subject Alternative Names (SAN). Verify they exist:
+
+```bash
+# Check server certificate SAN extensions
+openssl x509 -in server.crt -text -noout | grep -A 3 "Subject Alternative Name"
+
+# Expected output:
+# X509v3 Subject Alternative Name:
+#     DNS:localhost, IP Address:0:0:0:0:0:0:0:1, IP Address:127.0.0.1
+
+# Check client certificate SAN extensions
+openssl x509 -in client.crt -text -noout | grep -A 3 "Subject Alternative Name"
+```
+
+### 3. Test TLS Connection with OpenSSL s_client
+
+Before testing with TACACS+ client/server, verify the TLS handshake works:
+
+```bash
+# Test basic TLS connection (server certificate validation)
+echo | timeout 5 openssl s_client -connect localhost:49 -CAfile ca.crt -servername localhost
+
+# Test mutual TLS connection (client certificate authentication)
+echo | timeout 5 openssl s_client -connect localhost:49 -CAfile ca.crt \
+  -cert client.crt -key client.key -servername localhost
+```
+
+**What to look for in s_client output:**
+- `Verification: OK` - Certificate chain is valid
+- `Verify return code: 0 (ok)` - No certificate errors
+- `Protocol: TLSv1.3` - TLS 1.3 is being used
+- Certificate chain section showing your certificates
+
+### 4. Enable Detailed TLS Debugging
+
+For more detailed TLS debugging, add verbose flags to openssl s_client:
+
+```bash
+# Verbose TLS debugging
+echo | timeout 5 openssl s_client -connect localhost:49 -CAfile ca.crt \
+  -servername localhost -verify 3 -debug -msg
+
+# This shows:
+# - TLS handshake messages
+# - Certificate verification details
+# - Protocol negotiation
+# - Cipher suite selection
+```
+
+### 5. Debug TACACS+ Packet Issues
+
+If TLS connects but TACACS+ fails, check packet-level issues:
+
+```bash
+# Add debugging to see detailed error messages
+# Look for errors like:
+# "bad secret detected authenstart - expected len: 471, got: 10 (user:52 port:156 remAddr:205 data:58)"
+
+# This indicates:
+# - expected len: Sum of length fields from packet header
+# - got: Actual parsed field lengths
+# - Large garbage values suggest packet corruption or wrong encryption/decryption
+```
+
+### 6. Verify Server Logs
+
+Check server logs for detailed error information:
+
+```bash
+# Look for these log patterns:
+DEBUG: prefix secret provider matches remote [::1] against prefix [::/0]
+ERROR: closing connection, unable to read, remote error: tls: bad certificate
+ERROR: closing connection, unable to read, tls: failed to verify certificate: x509: certificate signed by unknown authority
+```
+
+### 7. Test Network Connectivity
+
+Ensure basic network connectivity works:
+
+```bash
+# Test if server port is accessible
+nc -zv localhost 6653
+# Expected: Connection to localhost 49 port [tcp/*] succeeded!
+
+# Test if TLS port responds
+echo | timeout 2 openssl s_client -connect localhost:6653
+# Should establish connection (even if certificate verification fails)
+```
+
+### 8. Common Debugging Scenarios
+
+#### Scenario 1: Certificate SAN Extension Missing
+**Symptoms:**
+```
+tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
+```
+
+**Debug Steps:**
+1. Check certificate SAN extensions with `openssl x509 -text`
+2. If missing, regenerate certificates with proper SAN configuration
+3. Verify both server and client certificates have SAN extensions
+
+#### Scenario 2: Certificate Authority Trust Issues
+**Symptoms:**
+```
+tls: failed to verify certificate: x509: certificate signed by unknown authority
+```
+
+**Debug Steps:**
+1. Verify certificate chain with `openssl verify`
+2. Test TLS connection with `openssl s_client`
+3. Check client has correct `-tls-ca` parameter
+4. Check server has correct `-tls-ca` parameter for client validation
+
+#### Scenario 3: Packet Length Mismatch
+**Symptoms:**
+```
+bad secret detected authenstart - expected len: 471, got: 10 (user:52 port:156 remAddr:205 data:58)
+```
+
+**Debug Steps:**
+1. Large garbage length values indicate TLS client configuration bug
+2. Verify client crypter has `tls=true` flag set
+3. Check that client sends packets with `UnencryptedFlag` set
+4. Verify server processes TLS packets correctly
+
+#### Scenario 4: TLS Handshake Succeeds but TACACS+ Fails
+**Symptoms:**
+```
+Connected to server using TLS
+execute pap authentication
+{Status:AuthenStatusError Flags: ServerMsg:unencrypted flag not set Data:}
+```
+
+**Debug Steps:**
+1. TLS layer is working correctly
+2. TACACS+ protocol layer has issues
+3. Check that client sends unencrypted packets within TLS tunnel
+4. Verify server expects unencrypted packets for TLS connections
+
+### 9. Step-by-Step Debugging Workflow
+
+When facing TLS issues, follow this systematic approach:
+
+1. **Start with certificate verification** - Use `openssl verify` and `openssl x509 -text`
+2. **Test basic TLS handshake** - Use `openssl s_client` before trying TACACS+
+3. **Check server logs** - Look for specific error messages
+4. **Test without mutual TLS first** - Verify server certificate validation works
+5. **Add client certificates gradually** - Test mutual TLS only after basic TLS works
+6. **Enable verbose logging** - Add debugging flags to see detailed error messages
+
+### 10. Useful OpenSSL Commands Reference
+
+```bash
+# Generate certificates with debugging
+openssl req -new -key server.key -out server.csr -config server.conf -verbose
+
+# View certificate details
+openssl x509 -in server.crt -text -noout
+
+# Test specific cipher suites
+echo | openssl s_client -connect localhost:6653 -cipher ECDHE-RSA-AES256-GCM-SHA384
+
+# Check certificate expiration
+openssl x509 -in server.crt -noout -dates
+
+# Verify certificate matches private key
+openssl x509 -noout -modulus -in server.crt | openssl md5
+openssl rsa -noout -modulus -in server.key | openssl md5
+# The MD5 hashes should match
+```
+
+## Security Considerations
+
+When deploying TACACS+ over TLS in production:
+
+1. Use properly signed certificates from a trusted Certificate Authority
+2. Ensure all certificates include proper SAN extensions
+3. Implement certificate revocation checking
+4. Regularly rotate certificates
+5. Consider using mutual TLS authentication for stronger security
+6. Follow your organization's PKI best practices
+7. Never use `-tls-insecure-skip-verify` in production
+
+## References
+
+- [IETF draft-ietf-opsawg-tacacs-tls13-07](https://www.ietf.org/archive/id/draft-ietf-opsawg-tacacs-tls13-07.html)
+- [TLS 1.3 RFC 8446](https://datatracker.ietf.org/doc/html/rfc8446)
+- [RFC 5280 - Certificate and Certificate Revocation List (CRL) Profile](https://datatracker.ietf.org/doc/html/rfc5280)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/google/uuid v1.3.0
-	github.com/prometheus/client_golang v1.13.0
+	github.com/prometheus/client_golang v1.19.1
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8
 	gopkg.in/yaml.v3 v3.0.1
@@ -14,14 +14,14 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/common v0.37.0 // indirect
-	github.com/prometheus/procfs v0.8.0 // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	github.com/prometheus/client_model v0.5.0 // indirect
+	github.com/prometheus/common v0.48.0 // indirect
+	github.com/prometheus/procfs v0.12.0 // indirect
+	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/facebookincubator/tacquito
 
-go 1.18
+go 1.23
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -101,6 +103,7 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -170,17 +173,23 @@ github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqr
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_golang v1.13.0 h1:b71QUfeo5M8gq2+evJdTPfZhYMAU0uKPkyPJ7TPsloU=
 github.com/prometheus/client_golang v1.13.0/go.mod h1:vTeo+zgvILHsnnj/39Ou/1fPN5nJFOEMgftOUOmlvYQ=
+github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
+github.com/prometheus/client_golang v1.19.1/go.mod h1:mP78NwGzrVks5S2H6ab8+ZZGJLZUq1hoULYBAYBw1Ho=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.5.0 h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=
+github.com/prometheus/client_model v0.5.0/go.mod h1:dTiFglRmd66nLR9Pv9f0mZi7B7fk5Pm3gvsjB5tr+kI=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 github.com/prometheus/common v0.37.0 h1:ccBbHCgIiT9uSoFY0vX8H3zsNR5eLt17/RQLUvn8pXE=
 github.com/prometheus/common v0.37.0/go.mod h1:phzohg0JFMnBEFGxTDbfu3QyL5GI8gTQJFhYO5B3mfA=
+github.com/prometheus/common v0.48.0 h1:QO8U2CdOzSn1BBsmXJXduaaW+dY/5QLjfB8svtSzKKE=
+github.com/prometheus/common v0.48.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5EC6ILDTlAPc=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
@@ -188,6 +197,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
+github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
+github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -335,6 +346,8 @@ golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
@@ -469,6 +482,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/server.go
+++ b/server.go
@@ -29,6 +29,14 @@ func SetUseProxy(v bool) Option {
 	}
 }
 
+// SetUseTLS enables TLS support for TACACS+ as defined in
+// https://www.ietf.org/archive/id/draft-ietf-opsawg-tacacs-tls13-07.html
+func SetUseTLS(v bool) Option {
+	return func(s *Server) {
+		s.useTLS = v
+	}
+}
+
 // NewServer returns a new server.
 // loggerProvider - the logging backend to use
 // listener - net.Listener
@@ -49,6 +57,9 @@ type Server struct {
 
 	// enables ha-proxy ascii proxy header support
 	proxy bool
+
+	// enables TACACS over TLS support
+	useTLS bool
 }
 
 // DeadlineListener is a net.Listener that supports Deadlines
@@ -123,7 +134,7 @@ func (s *Server) serve(ctx context.Context, conn net.Conn) {
 	}
 	ctx = context.WithValue(ctx, ContextLoaderDuration, time.Since(loaderStart).Milliseconds())
 	serveAccepted.Inc()
-	s.handle(ctx, newCrypter(secret, conn, s.proxy), handler)
+	s.handle(ctx, newCrypter(secret, conn, s.proxy, s.useTLS), handler)
 	serveAccepted.Dec()
 }
 

--- a/stats.go
+++ b/stats.go
@@ -73,6 +73,11 @@ var (
 		Name:      "crypter_marshal_error",
 		Help:      "number of errors marshalling in crypter",
 	})
+	crypterReadFlagError = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "tacquito",
+		Name:      "crypter_tls_read_error",
+		Help:      "number of errors the tls unencrypted flag was unset on a conn read",
+	})
 	waitgroupActive = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "tacquito",
 		Name:      "waitgroup_handle_routines_active",
@@ -133,6 +138,7 @@ func init() {
 	prometheus.MustRegister(crypterUnmarshalError)
 	prometheus.MustRegister(crypterMarshalError)
 	prometheus.MustRegister(crypterCryptError)
+	prometheus.MustRegister(crypterReadFlagError)
 	prometheus.MustRegister(waitgroupActive)
 	prometheus.MustRegister(sessionsActive)
 	prometheus.MustRegister(sessionsGetHit)

--- a/tls.go
+++ b/tls.go
@@ -3,9 +3,12 @@ package tacquito
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -45,21 +48,19 @@ func (l *TLSDeadlineListener) SetDeadline(t time.Time) error {
 func GenTLSConfig(certFile, keyFile, CAFile string, requireMutualAuth bool) (*tls.Config, error) {
 	config := &tls.Config{
 		MinVersion: tls.VersionTLS13,            // Require TLS 1.3 as per the IETF draft
-		ClientAuth: tls.VerifyClientCertIfGiven, // Mutual authentication is optional
+		ClientAuth: tls.VerifyClientCertIfGiven, // Mutual authentication is optional to start with, but is highly recommended
 	}
 
 	if certFile == "" || keyFile == "" {
 		return nil, errors.New("TLS is enabled but certificate or key file is not provided")
 	}
 
-	// Load server certificate and key
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, err
 	}
 	config.Certificates = []tls.Certificate{cert}
 
-	// Configure client certificate verification if CA file is provided
 	if CAFile != "" {
 		data, err := os.ReadFile(CAFile)
 		if err != nil {
@@ -80,26 +81,25 @@ func GenTLSConfig(certFile, keyFile, CAFile string, requireMutualAuth bool) (*tl
 }
 
 // createTLSConfig creates a TLS configuration based on the provided command-line flags
-func GenClientTLSConfig(serverName, certFile, keyFile, CAFile string, skipVerification bool) (*tls.Config, error) {
+func GenClientTLSConfig(p *ParsedTLSConfig) (*tls.Config, error) {
 	config := &tls.Config{
 		MinVersion:         tls.VersionTLS13, // Require TLS 1.3 as per the IETF draft
-		ServerName:         serverName,
-		InsecureSkipVerify: skipVerification,
+		ServerName:         p.ServerName,
+		InsecureSkipVerify: p.InsecureSkipVerify, // false by default
 	}
 
-	if certFile == "" || keyFile == "" {
+	if p.CertFile == "" || p.KeyFile == "" {
 		return nil, errors.New("Client config: TLS is enabled but certificate or key file is not provided")
 	}
 
-	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	cert, err := tls.LoadX509KeyPair(p.CertFile, p.KeyFile)
 	if err != nil {
 		return nil, err
 	}
 	config.Certificates = []tls.Certificate{cert}
 
-	// Set RootCAs for server certificate verification if CA file is provided
-	if CAFile != "" {
-		data, err := os.ReadFile(CAFile)
+	if p.CAFile != "" {
+		data, err := os.ReadFile(p.CAFile)
 		if err != nil {
 			return nil, err
 		}
@@ -111,4 +111,94 @@ func GenClientTLSConfig(serverName, certFile, keyFile, CAFile string, skipVerifi
 	}
 
 	return config, nil
+}
+
+// TLSConfig represents the TLS configuration that can be loaded from a JSON file
+// If a TLS config file is specified, TLS is automatically enabled
+type ParsedTLSConfig struct {
+	// Certificate files
+	CertFile string `json:"cert_file"`
+	KeyFile  string `json:"key_file"`
+	CAFile   string `json:"ca_file"`
+
+	// Server name for certificate validation
+	ServerName string `json:"server_name"`
+
+	// Skip certificate verification (not recommended for production)
+	InsecureSkipVerify bool `json:"insecure_skip_verify"`
+}
+
+// LoadTLSConfig loads TLS configuration from a JSON file
+func LoadTLSConfig(filename string) (*ParsedTLSConfig, error) {
+	if filename == "" {
+		return nil, fmt.Errorf("TLS config file path is empty")
+	}
+
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return nil, fmt.Errorf("TLS config file does not exist: %s", filename)
+	}
+
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read TLS config file: %w", err)
+	}
+
+	var config ParsedTLSConfig
+	err = json.Unmarshal(data, &config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JSON TLS config: %w", err)
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid TLS config: %w", err)
+	}
+
+	return &config, nil
+}
+
+// Validate checks if the TLS configuration is valid
+func (c *ParsedTLSConfig) Validate() error {
+	var err error
+
+	if c.CertFile, err = resolvePath(c.CertFile, "TLS certificate"); err != nil {
+		return err
+	}
+
+	if c.KeyFile, err = resolvePath(c.KeyFile, "TLS key"); err != nil {
+		return err
+	}
+
+	if c.CAFile, err = resolvePath(c.CAFile, "TLS CA"); err != nil {
+		return err
+	}
+
+	// If client cert is specified, key must also be specified and vice versa
+	if c.CertFile != "" && c.KeyFile == "" {
+		return fmt.Errorf("TLS key file must be specified when certificate file is provided")
+	}
+	if c.KeyFile != "" && c.CertFile == "" {
+		return fmt.Errorf("TLS certificate file must be specified when key file is provided")
+	}
+
+	return nil
+}
+
+// resolvePath converts relative paths to absolute paths and checks if the file exists
+// Returns the absolute path and an error if the file doesn't exist or path conversion fails
+func resolvePath(path, fileType string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+
+	// Convert to absolute path (handles relative paths like ./file or ../file)
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert %s file path '%s' to absolute path: %w", fileType, path, err)
+	}
+
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("%s file does not exist: %s", fileType, absPath)
+	}
+
+	return absPath, nil
 }

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,114 @@
+package tacquito
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net"
+	"os"
+	"time"
+)
+
+// tlsDeadlineListener wraps a TLS listener to implement DeadlineListener
+type TLSDeadlineListener struct {
+	net.Listener
+	tcpListener *net.TCPListener
+}
+
+func NewTLSListener(l net.Listener, config *tls.Config) (*TLSDeadlineListener, error) {
+	if config == nil {
+		return nil, errors.New("TLS config cannot be nil")
+	}
+
+	// Get the underlying TCP listener
+	tcpListener, ok := l.(*net.TCPListener)
+	if !ok {
+		return nil, errors.New("listener must be a TCP listener for TLS support")
+	}
+
+	// Create a TLS listener
+	tlsListener := tls.NewListener(tcpListener, config)
+
+	// Wrap the TLS listener to implement DeadlineListener
+	return &TLSDeadlineListener{
+		Listener:    tlsListener,
+		tcpListener: tcpListener,
+	}, nil
+}
+
+// SetDeadline implements DeadlineListener interface
+func (l *TLSDeadlineListener) SetDeadline(t time.Time) error {
+	return l.tcpListener.SetDeadline(t)
+}
+
+// GenTLSConfig creates a TLS configuration for a TLS server
+func GenTLSConfig(certFile, keyFile, CAFile string, requireMutualAuth bool) (*tls.Config, error) {
+	config := &tls.Config{
+		MinVersion: tls.VersionTLS13,            // Require TLS 1.3 as per the IETF draft
+		ClientAuth: tls.VerifyClientCertIfGiven, // Mutual authentication is optional
+	}
+
+	// If TLS is enabled but no certificate/key files are provided, log a warning
+	if certFile == "" || keyFile == "" {
+		return nil, errors.New("TLS is enabled but certificate or key file is not provided. Server may fail to start.")
+	}
+
+	// Load server certificate and key
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+	config.Certificates = []tls.Certificate{cert}
+
+	// Configure client certificate verification if CA file is provided
+	if CAFile != "" {
+		data, err := os.ReadFile(CAFile)
+		if err != nil {
+			return nil, err
+		}
+		certPool := x509.NewCertPool()
+		if !certPool.AppendCertsFromPEM(data) {
+			return nil, errors.New("failed to append CA certificates")
+		}
+		config.ClientCAs = certPool
+	}
+
+	if requireMutualAuth {
+		config.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	return config, nil
+}
+
+// createTLSConfig creates a TLS configuration based on the provided command-line flags
+func GenClientTLSConfig(serverName, certFile, keyFile, CAFile string, skipVerification bool) (*tls.Config, error) {
+	config := &tls.Config{
+		MinVersion:         tls.VersionTLS13, // Require TLS 1.3 as per the IETF draft
+		ServerName:         serverName,
+		InsecureSkipVerify: skipVerification,
+	}
+
+	// Load client certificate and key if provided
+	if certFile != "" && keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, err
+		}
+		config.Certificates = []tls.Certificate{cert}
+	}
+
+	// Set RootCAs for server certificate verification if CA file is provided
+	if CAFile != "" {
+		data, err := os.ReadFile(CAFile)
+		if err != nil {
+			return nil, err
+		}
+		certPool := x509.NewCertPool()
+		if !certPool.AppendCertsFromPEM(data) {
+			return nil, errors.New("failed to append CA certificates")
+		}
+		config.RootCAs = certPool // Use RootCAs for client, not ClientCAs
+	}
+
+	return config, nil
+}

--- a/tls_client_option.go
+++ b/tls_client_option.go
@@ -1,0 +1,60 @@
+/*
+ Copyright (c) Facebook, Inc. and its affiliates.
+
+ This source code is licensed under the MIT license found in the
+ LICENSE file in the root directory of this source tree.
+*/
+
+package tacquito
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+// SetClientTLSDialer creates a client that connects to the server using TLS.
+// network and address specify the server to connect to.
+// tlsConfig is the TLS configuration to use for the connection.
+func SetClientTLSDialer(network, address string, tlsConfig *tls.Config) ClientOption {
+	return func(c *Client) error {
+		// Connect to the server using TLS
+		conn, err := tls.Dial(network, address, tlsConfig)
+		if err != nil {
+			return err
+		}
+		c.crypter = newCrypter(nil, conn, false, true)
+		return nil
+	}
+}
+
+// SetClientTLSDialerWithLocalAddr creates a client that connects to the server using TLS,
+// allowing specification of the local address to connect from.
+// network and raddr specify the server to connect to.
+// laddr specifies the local address to connect from.
+// tlsConfig is the TLS configuration to use for the connection.
+func SetClientTLSDialerWithLocalAddr(network, raddr, laddr string, tlsConfig *tls.Config) ClientOption {
+	return func(c *Client) error {
+		// Resolve the local address if provided
+		var localAddr *net.TCPAddr
+		var err error
+		if laddr != "" {
+			localAddr, err = net.ResolveTCPAddr(network, laddr)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Create a dialer with the local address
+		dialer := &net.Dialer{
+			LocalAddr: localAddr,
+		}
+
+		// Connect to the server using TLS with the dialer
+		conn, err := tls.DialWithDialer(dialer, network, raddr, tlsConfig)
+		if err != nil {
+			return err
+		}
+		c.crypter = newCrypter(nil, conn, false, true)
+		return nil
+	}
+}

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,0 +1,365 @@
+/*
+ Copyright (c) Facebook, Inc. and its affiliates.
+
+ This source code is licensed under the MIT license found in the
+ LICENSE file in the root directory of this source tree.
+*/
+
+package tacquito
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolvePath tests the resolvePath function with various path inputs
+func TestResolvePath(t *testing.T) {
+	// We need to create some temporary state to test resolvePath with
+	tempDir, err := os.MkdirTemp("", "tls_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	testFile := filepath.Join(tempDir, "test.cert")
+	err = os.WriteFile(testFile, []byte("test cert content"), 0644)
+	require.NoError(t, err)
+
+	subDir := filepath.Join(tempDir, "subdir")
+	err = os.MkdirAll(subDir, 0755)
+	require.NoError(t, err)
+
+	subFile := filepath.Join(subDir, "sub.cert")
+	err = os.WriteFile(subFile, []byte("sub cert content"), 0644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		path      string
+		fileType  string
+		shouldErr bool
+		errMsg    string
+		setup     func() string // function to set up path relative to tempDir
+	}{
+		{
+			name:     "empty path",
+			path:     "",
+			fileType: "certificate",
+		},
+		{
+			name:     "existing absolute path",
+			fileType: "certificate",
+			setup: func() string {
+				return testFile
+			},
+		},
+		{
+			name:     "existing relative path",
+			fileType: "certificate",
+			setup: func() string {
+				// Change to tempDir and use relative path
+				original, _ := os.Getwd()
+				os.Chdir(tempDir)
+				t.Cleanup(func() { os.Chdir(original) })
+				return "test.cert"
+			},
+		},
+		{
+			name:      "non-existing file",
+			path:      "/non/existent/file.cert",
+			fileType:  "certificate",
+			shouldErr: true,
+			errMsg:    "certificate file does not exist",
+		},
+		{
+			name:      "non-existent file from relative path",
+			fileType:  "certificate",
+			shouldErr: true,
+			errMsg:    "certificate file does not exist",
+			setup: func() string {
+				return filepath.Join(tempDir, "nonexistent.cert")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tt.path
+			if tt.setup != nil {
+				path = tt.setup()
+			}
+
+			result, err := resolvePath(path, tt.fileType)
+
+			if tt.shouldErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if path == "" {
+				assert.Equal(t, "", result)
+			} else {
+				// Result should be absolute path
+				assert.True(t, filepath.IsAbs(result))
+
+				// If file should exist, verify it does
+				if !strings.Contains(tt.name, "non-existing") && !strings.Contains(tt.name, "nonexistent") {
+					_, statErr := os.Stat(result)
+					assert.NoError(t, statErr, "resolved file should exist")
+				}
+			}
+		})
+	}
+}
+
+func TestParsedTLSConfigValidate(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "tls_config_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	certFile := filepath.Join(tempDir, "cert.pem")
+	keyFile := filepath.Join(tempDir, "key.pem")
+	caFile := filepath.Join(tempDir, "ca.pem")
+
+	for _, file := range []string{certFile, keyFile, caFile} {
+		err = os.WriteFile(file, []byte("dummy content"), 0644)
+		require.NoError(t, err)
+	}
+
+	tests := []struct {
+		name      string
+		config    ParsedTLSConfig
+		shouldErr bool
+		errMsg    string
+		setup     func(*ParsedTLSConfig)
+	}{
+		{
+			name: "valid absolute paths",
+			config: ParsedTLSConfig{
+				CertFile: certFile,
+				KeyFile:  keyFile,
+				CAFile:   caFile,
+			},
+		},
+		{
+			name: "valid relative paths",
+			config: ParsedTLSConfig{
+				CertFile: "./cert.pem",
+				KeyFile:  "./key.pem",
+				CAFile:   "./ca.pem",
+			},
+			setup: func(config *ParsedTLSConfig) {
+				// Change to temp directory for relative paths to work
+				original, _ := os.Getwd()
+				os.Chdir(tempDir)
+				t.Cleanup(func() { os.Chdir(original) })
+			},
+		},
+		{
+			name: "cert without key",
+			config: ParsedTLSConfig{
+				CertFile: certFile,
+				// KeyFile is empty
+			},
+			shouldErr: true,
+			errMsg:    "TLS key file must be specified when certificate file is provided",
+		},
+		{
+			name: "key without cert",
+			config: ParsedTLSConfig{
+				KeyFile: keyFile,
+				// CertFile is empty
+			},
+			shouldErr: true,
+			errMsg:    "TLS certificate file must be specified when key file is provided",
+		},
+		{
+			name: "non-existent cert file",
+			config: ParsedTLSConfig{
+				CertFile: "/non/existent/cert.pem",
+				KeyFile:  keyFile,
+			},
+			shouldErr: true,
+			errMsg:    "TLS certificate file does not exist",
+		},
+		{
+			name: "non-existent key file",
+			config: ParsedTLSConfig{
+				CertFile: certFile,
+				KeyFile:  "/non/existent/key.pem",
+			},
+			shouldErr: true,
+			errMsg:    "TLS key file does not exist",
+		},
+		{
+			name: "non-existent CA file",
+			config: ParsedTLSConfig{
+				CertFile: certFile,
+				KeyFile:  keyFile,
+				CAFile:   "/non/existent/ca.pem",
+			},
+			shouldErr: true,
+			errMsg:    "TLS CA file does not exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tt.config
+
+			if tt.setup != nil {
+				tt.setup(&config)
+			}
+
+			err := config.Validate()
+
+			if tt.shouldErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+				return
+			}
+
+			assert.NoError(t, err)
+
+			// Verify that paths have been resolved to absolute paths
+			if config.CertFile != "" {
+				assert.True(t, filepath.IsAbs(config.CertFile))
+			}
+			if config.KeyFile != "" {
+				assert.True(t, filepath.IsAbs(config.KeyFile))
+			}
+			if config.CAFile != "" {
+				assert.True(t, filepath.IsAbs(config.CAFile))
+			}
+		})
+	}
+}
+
+func TestLoadTLSConfig(t *testing.T) {
+	// Create temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "tls_config_load_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create test certificate files
+	certFile := filepath.Join(tempDir, "server.crt")
+	keyFile := filepath.Join(tempDir, "server.key")
+	caFile := filepath.Join(tempDir, "ca.crt")
+
+	for _, file := range []string{certFile, keyFile, caFile} {
+		err = os.WriteFile(file, []byte("dummy cert content"), 0644)
+		require.NoError(t, err)
+	}
+
+	tests := []struct {
+		name         string
+		configJSON   map[string]interface{}
+		shouldErr    bool
+		errMsg       string
+		validateFunc func(*testing.T, *ParsedTLSConfig)
+	}{
+		{
+			name: "valid config with absolute paths",
+			configJSON: map[string]interface{}{
+				"cert_file":            certFile,
+				"key_file":             keyFile,
+				"ca_file":              caFile,
+				"server_name":          "test",
+				"insecure_skip_verify": false,
+			},
+			validateFunc: func(t *testing.T, config *ParsedTLSConfig) {
+				assert.Equal(t, certFile, config.CertFile)
+				assert.Equal(t, keyFile, config.KeyFile)
+				assert.Equal(t, caFile, config.CAFile)
+				assert.Equal(t, "test", config.ServerName)
+				assert.False(t, config.InsecureSkipVerify)
+			},
+		},
+		{
+			name: "config with relative paths",
+			configJSON: map[string]interface{}{
+				"cert_file": "./server.crt",
+				"key_file":  "./server.key",
+				"ca_file":   "./ca.crt",
+			},
+			validateFunc: func(t *testing.T, config *ParsedTLSConfig) {
+				// Paths should be resolved to absolute paths
+				assert.True(t, filepath.IsAbs(config.CertFile))
+				assert.True(t, filepath.IsAbs(config.KeyFile))
+				assert.True(t, filepath.IsAbs(config.CAFile))
+
+				// Files should exist
+				for _, path := range []string{config.CertFile, config.KeyFile, config.CAFile} {
+					_, err := os.Stat(path)
+					assert.NoError(t, err)
+				}
+			},
+		},
+		{
+			name: "cert without key",
+			configJSON: map[string]interface{}{
+				"cert_file": certFile,
+			},
+			shouldErr: true,
+			errMsg:    "TLS key file must be specified when certificate file is provided",
+		},
+		{
+			name: "non-existent files",
+			configJSON: map[string]interface{}{
+				"cert_file": "/non/existent/cert.pem",
+				"key_file":  "/non/existent/key.pem",
+			},
+			shouldErr: true,
+			errMsg:    "TLS certificate file does not exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configFile := filepath.Join(tempDir, fmt.Sprintf("config_%s.json", strings.ReplaceAll(tt.name, " ", "_")))
+
+			// For relative paths test, change to temp directory
+			if tt.name == "config with relative paths" {
+				original, _ := os.Getwd()
+				os.Chdir(tempDir)
+				defer os.Chdir(original)
+			}
+
+			configData, err := json.Marshal(tt.configJSON)
+			require.NoError(t, err)
+
+			err = os.WriteFile(configFile, configData, 0644)
+			require.NoError(t, err)
+
+			// Load configuration
+			config, err := LoadTLSConfig(configFile)
+
+			if tt.shouldErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, config)
+
+			if tt.validateFunc != nil {
+				tt.validateFunc(t, config)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds experimental support for TACACS over TLS RFC [draft-ietf-opsawg-tacacs-tls13-07](https://datatracker.ietf.org/doc/draft-ietf-opsawg-tacacs-tls13/07/)

Change summary:

## Core Protocol Changes
- Modified crypter to handle TLS vs non-TLS connections properly
- TLS connections skip traditional TACACS+ PSK obfuscation
- Added UnencryptedFlag validation for TLS connections
- Enhanced error handling for TLS protocol violations

## Server & Client Features  
- Added TLS listener support with configurable certificates
- Command-line options for TLS certificate configuration
- Support for mutual TLS authentication with client certificates
- Certificate-based authentication with SAN extensions
- Backward compatibility with existing non-TLS deployments

## New Files Added
- tls.go: Core TLS configuration and listener management
- tls_client_option.go: TLS client configuration options
- docs/tls_support.md: Comprehensive TLS setup and debugging guide
- server_tls_bench_test.go: TLS performance benchmarks
- server_tls_optimized_bench_test.go: Optimized TLS benchmarks

## Command Line Interface
### Server Options:
- -tls: Enable TLS support  
- -tls-cert: Server certificate file path
- -tls-key: Server private key file path
- -tls-ca: CA certificate for client validation
- -tls-require-client-cert: Require mutual TLS

### Client Options:
- -tls: Enable TLS support
- -tls-cert: Client certificate for mutual TLS
- -tls-key: Client private key for mutual TLS  
- -tls-ca: CA certificate for server validation
- -tls-server-name: Server name for certificate validation
- -tls-insecure-skip-verify: Skip certificate validation (testing only)

## Security & Performance
- Requires TLS 1.3 as per IETF specification
- Comprehensive certificate validation with SAN support
- Performance optimizations for TLS handshake overhead
- Extensive test coverage including surge testing

This implementation follows IETF draft-ietf-opsawg-tacacs-tls13-07 specification 
for secure TACACS+ authentication over TLS transport."