### PR TITLE
Fix format string vulnerabilities in span.go error handling

### DIFF
--- a/cmds/server/handlers/span.go
+++ b/cmds/server/handlers/span.go
@@ -96,7 +96,7 @@ func (w writer) Write(ctx context.Context, p []byte) (int, error) {
 		spanHandleWriteError.Inc()
 		s := fmt.Sprintf("Skipping packet, switchAddr don't match, actual addr %v vs configured addr %v", remoteAddr, w.switchAddr)
 		w.Errorf(w.ctx, s)
-		return 0, fmt.Errorf(s)
+		return 0, fmt.Errorf("%s", s)
 	}
 	packet := tq.NewPacket()
 	packet.UnmarshalBinary(p)
@@ -104,7 +104,7 @@ func (w writer) Write(ctx context.Context, p []byte) (int, error) {
 		spanHandleWriteError.Inc()
 		s := fmt.Sprintf("Skipping packet, Packet types don't match, actual type %v vs configured type %v", packet.Header.Type, w.packetType)
 		w.Errorf(w.ctx, s)
-		return 0, fmt.Errorf(s)
+		return 0, fmt.Errorf("%s", s)
 	}
 	if w.remAddr != "" {
 		req := tq.Request{Header: *packet.Header, Body: packet.Body[:]}
@@ -114,7 +114,7 @@ func (w writer) Write(ctx context.Context, p []byte) (int, error) {
 			spanHandleWriteError.Inc()
 			s := fmt.Sprintf("Skipping packet, client IPs don't match, actual client IP %v vs configured IP %v", remAddrField, w.remAddr)
 			w.Errorf(w.ctx, s)
-			return 0, fmt.Errorf(s)
+			return 0, fmt.Errorf("%s", s)
 		}
 	}
 	n, err := w.Conn.Write(p)


### PR DESCRIPTION
Showed up after the recent upgrade to go1.24 in go.mod

Before
```
~/g/tacquito ❯❯❯ go test ./...                                                                                                                                                                                                                            ✘ 1
# github.com/facebookincubator/tacquito/cmds/server/handlers
cmds/server/handlers/span.go:99:24: non-constant format string in call to fmt.Errorf
cmds/server/handlers/span.go:107:24: non-constant format string in call to fmt.Errorf
cmds/server/handlers/span.go:117:25: non-constant format string in call to fmt.Errorf
ok      github.com/facebookincubator/tacquito   2.591s
?       github.com/facebookincubator/tacquito/cmds/client       [no test files]
?       github.com/facebookincubator/tacquito/cmds/server       [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config        [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/accounters/local       [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/accounters/syslog      [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/authenticators [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/authenticators/bcrypt  [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/authenticators/bcrypt/generator        [no test files]
ok      github.com/facebookincubator/tacquito/cmds/server/config/authorizers/stringy    1.019s
ok      github.com/facebookincubator/tacquito/cmds/server/config/authorizers/stringy/test       1.435s
?       github.com/facebookincubator/tacquito/cmds/server/config/secret [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/secret/dns     [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/secret/prefix  [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/exporter      [no test files]
FAIL    github.com/facebookincubator/tacquito/cmds/server/handlers [build failed]
ok      github.com/facebookincubator/tacquito/cmds/server/loader        1.597s
?       github.com/facebookincubator/tacquito/cmds/server/loader/fsnotify       [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/loader/json   [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/loader/yaml   [no test files]
ok      github.com/facebookincubator/tacquito/cmds/server/log   6.164s
ok      github.com/facebookincubator/tacquito/cmds/server/test  10.234s
ok      github.com/facebookincubator/tacquito/proxy     2.466s
FAIL
```

After
```
~/g/t/c/server ❯❯❯ go test ./...
?       github.com/facebookincubator/tacquito/cmds/server       [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config        [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/accounters/local       [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/accounters/syslog      [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/authenticators [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/authenticators/bcrypt  [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/authenticators/bcrypt/generator        [no test files]
ok      github.com/facebookincubator/tacquito/cmds/server/config/authorizers/stringy    (cached)
ok      github.com/facebookincubator/tacquito/cmds/server/config/authorizers/stringy/test       (cached)
?       github.com/facebookincubator/tacquito/cmds/server/config/secret [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/secret/dns     [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/config/secret/prefix  [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/exporter      [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/handlers      [no test files]
ok      github.com/facebookincubator/tacquito/cmds/server/loader        (cached)
?       github.com/facebookincubator/tacquito/cmds/server/loader/fsnotify       [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/loader/json   [no test files]
?       github.com/facebookincubator/tacquito/cmds/server/loader/yaml   [no test files]
ok      github.com/facebookincubator/tacquito/cmds/server/log   (cached)
ok      github.com/facebookincubator/tacquito/cmds/server/test  (cached)
```