### PR TITLE
Update push.yml in accordance with go.mod

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.23
+          go-version: 1.24
 
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
To address a recent CVE-2025-58181, we upgraded to go version in go.mod to 1.24. Modifying push workflow in accordance with this