### PR TITLE
Add MultiSecretProvider for hitless shared-secret rotation

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -110,6 +110,10 @@ type crypter struct {
 	// setting the tls parameters enables RFC 9887 specific handling
 	// within the crypter
 	tls bool
+
+	// altSecrets are tried in order on the first read() when secret
+	// fails detectBadSecret; the first match becomes secret thereafter
+	altSecrets [][]byte
 }
 
 // read will read a packet from the underlying net.Conn and decyrpt it
@@ -170,9 +174,29 @@ func (c *crypter) read() (*Packet, error) {
 		// if reply is != nil, we found a bad secret.
 		// if both are non nil, we only inspect the error as that
 		// is a higher error condition in the server than a bad secret is
-		if reply, err := c.detectBadSecret(&p); err != nil {
+		reply, err := c.detectBadSecret(&p)
+		if err != nil {
 			return nil, err
-		} else if reply != nil {
+		}
+		// MultiSecretProvider: retry alternates from a snapshot of the
+		// obfuscated body (first packet only).
+		if reply != nil && len(c.altSecrets) > 0 {
+			// b holds the original obfuscated body; p.Body is a separate alloc after Unmarshal
+			obfuscated := b
+			for _, cand := range c.altSecrets {
+				p.Body = append(p.Body[:0], obfuscated...)
+				// header conditions already validated on the primary attempt above
+				_ = crypt(cand, &p)
+				reply, _ = c.detectBadSecret(&p)
+				if reply == nil {
+					c.secret = cand
+					crypterAltSecretSelected.Inc()
+					break
+				}
+			}
+		}
+		c.altSecrets = nil
+		if reply != nil {
 			if _, err := c.write(reply); err != nil {
 				return nil, fmt.Errorf("bad secret, crypt write fail for ip [%s]: %w", c.RemoteAddr().String(), err)
 			}
@@ -187,7 +211,7 @@ func (c *crypter) read() (*Packet, error) {
 		*/
 		if !p.Header.Flags.Has(UnencryptedFlag) {
 			crypterReadFlagError.Inc()
-			reply, err := c.unsetFlagReply(p.Header)
+			reply, err := c.unsetFlagReply(*p.Header)
 			if err != nil {
 				return nil, err
 			}
@@ -262,7 +286,7 @@ func (c crypter) detectBadSecret(p *Packet) (*Packet, error) {
 		if errCnt == 3 {
 			crypterBadSecret.Inc()
 			// all packet types failed, most likley a bad secret
-			return c.badSecretReply(p.Header)
+			return c.badSecretReply(*p.Header)
 		}
 	case Authorize:
 		errCnt := 0
@@ -277,7 +301,7 @@ func (c crypter) detectBadSecret(p *Packet) (*Packet, error) {
 		if errCnt == 2 {
 			crypterBadSecret.Inc()
 			// all packet types failed, most likley a bad secret
-			return c.badSecretReply(p.Header)
+			return c.badSecretReply(*p.Header)
 		}
 	case Accounting:
 		errCnt := 0
@@ -292,13 +316,13 @@ func (c crypter) detectBadSecret(p *Packet) (*Packet, error) {
 		if errCnt == 2 {
 			crypterBadSecret.Inc()
 			// all packet types failed, most likley a bad secret
-			return c.badSecretReply(p.Header)
+			return c.badSecretReply(*p.Header)
 		}
 	}
 	return nil, nil
 }
 
-func (c crypter) unsetFlagReply(h *Header) (*Packet, error) {
+func (c crypter) unsetFlagReply(h Header) (*Packet, error) {
 	var b []byte
 	var err error
 	switch h.Type {
@@ -339,12 +363,15 @@ func (c crypter) unsetFlagReply(h *Header) (*Packet, error) {
 	h.Flags.Set(UnencryptedFlag)
 
 	return NewPacket(
-		SetPacketHeader(h),
+		SetPacketHeader(&h),
 		SetPacketBody(b),
 	), nil
 }
 
-func (c crypter) badSecretReply(h *Header) (*Packet, error) {
+// badSecretReply builds the error reply for a presumed bad secret. It
+// takes Header by value so the caller's request header is not mutated;
+// the reply's Length and SeqNo differ from the request's.
+func (c crypter) badSecretReply(h Header) (*Packet, error) {
 	var b []byte
 	var err error
 	switch h.Type {
@@ -383,7 +410,7 @@ func (c crypter) badSecretReply(h *Header) (*Packet, error) {
 	// produces the correct parity for whichever side is sending the reply.
 	h.SeqNo++
 	p := NewPacket(
-		SetPacketHeader(h),
+		SetPacketHeader(&h),
 		SetPacketBody(b),
 	)
 	if err != nil {

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -247,7 +247,7 @@ func TestUnsetFlagReplyAuthenticate(t *testing.T) {
 		SetHeaderSeqNo(5),
 	)
 
-	reply, err := c.unsetFlagReply(header)
+	reply, err := c.unsetFlagReply(*header)
 	assert.NoError(t, err)
 	assert.NotNil(t, reply)
 
@@ -273,7 +273,7 @@ func TestUnsetFlagReplyAuthorize(t *testing.T) {
 		SetHeaderSeqNo(5),
 	)
 
-	reply, err := c.unsetFlagReply(header)
+	reply, err := c.unsetFlagReply(*header)
 	assert.NoError(t, err)
 	assert.NotNil(t, reply)
 
@@ -299,7 +299,7 @@ func TestUnsetFlagReplyAccounting(t *testing.T) {
 		SetHeaderSeqNo(5),
 	)
 
-	reply, err := c.unsetFlagReply(header)
+	reply, err := c.unsetFlagReply(*header)
 	assert.NoError(t, err)
 	assert.NotNil(t, reply)
 
@@ -324,7 +324,7 @@ func TestUnsetFlagReplyInvalidType(t *testing.T) {
 		SetHeaderSessionID(12345),
 	)
 
-	reply, err := c.unsetFlagReply(header)
+	reply, err := c.unsetFlagReply(*header)
 	assert.Error(t, err)
 	assert.Nil(t, reply)
 	assert.Contains(t, err.Error(), "unknown header type")
@@ -340,7 +340,7 @@ func TestBadSecretReplyAuthenticate(t *testing.T) {
 		SetHeaderSeqNo(5),
 	)
 
-	reply, err := c.badSecretReply(header)
+	reply, err := c.badSecretReply(*header)
 	assert.NoError(t, err)
 	assert.NotNil(t, reply)
 
@@ -365,7 +365,7 @@ func TestBadSecretReplyAuthorize(t *testing.T) {
 		SetHeaderSeqNo(5),
 	)
 
-	reply, err := c.badSecretReply(header)
+	reply, err := c.badSecretReply(*header)
 	assert.NoError(t, err)
 	assert.NotNil(t, reply)
 
@@ -390,7 +390,7 @@ func TestBadSecretReplyAccounting(t *testing.T) {
 		SetHeaderSeqNo(5),
 	)
 
-	reply, err := c.badSecretReply(header)
+	reply, err := c.badSecretReply(*header)
 	assert.NoError(t, err)
 	assert.NotNil(t, reply)
 
@@ -414,7 +414,7 @@ func TestBadSecretReplyInvalidType(t *testing.T) {
 		SetHeaderSessionID(12345),
 	)
 
-	reply, err := c.badSecretReply(header)
+	reply, err := c.badSecretReply(*header)
 	assert.Error(t, err)
 	assert.Nil(t, reply)
 	assert.Contains(t, err.Error(), "unknown header type")

--- a/multisecret_test.go
+++ b/multisecret_test.go
@@ -1,0 +1,357 @@
+/*
+ Copyright (c) Facebook, Inc. and its affiliates.
+
+ This source code is licensed under the MIT license found in the
+ LICENSE file in the root directory of this source tree.
+*/
+
+package tacquito
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// obfuscatedBytes wraps a marshalled body in a packet header of the given
+// type, obfuscates it with secret, and returns the wire bytes a client
+// would send.
+func obfuscatedBytes(t testing.TB, ht HeaderType, body []byte, secret []byte) []byte {
+	p := NewPacket(
+		SetPacketHeader(NewHeader(
+			SetHeaderVersion(Version{MajorVersion: MajorVersion, MinorVersion: MinorVersionDefault}),
+			SetHeaderType(ht),
+			SetHeaderSeqNo(1),
+			SetHeaderSessionID(0x1234),
+		)),
+		SetPacketBody(body),
+	)
+	require.NoError(t, crypt(secret, p))
+	wire, err := p.MarshalBinary()
+	require.NoError(t, err)
+	return wire
+}
+
+// obfuscatedPacketBytes builds a minimal AuthorRequest packet obfuscated
+// with the given secret.
+func obfuscatedPacketBytes(t testing.TB, secret []byte) []byte {
+	body, err := NewAuthorRequest(
+		SetAuthorRequestMethod(AuthenMethodTacacsPlus),
+		SetAuthorRequestPrivLvl(PrivLvlRoot),
+		SetAuthorRequestType(AuthenTypeASCII),
+		SetAuthorRequestService(AuthenServiceLogin),
+		SetAuthorRequestUser("rotation-test"),
+		SetAuthorRequestPort("tty0"),
+		SetAuthorRequestRemAddr("10.0.0.1"),
+	).MarshalBinary()
+	require.NoError(t, err)
+	return obfuscatedBytes(t, Authorize, body, secret)
+}
+
+func obfuscatedAuthenStartBytes(t testing.TB, secret []byte) []byte {
+	body, err := NewAuthenStart(
+		SetAuthenStartAction(AuthenActionLogin),
+		SetAuthenStartPrivLvl(PrivLvlUser),
+		SetAuthenStartType(AuthenTypeASCII),
+		SetAuthenStartService(AuthenServiceLogin),
+		SetAuthenStartUser("rotation-test"),
+		SetAuthenStartPort("tty0"),
+		SetAuthenStartRemAddr("10.0.0.1"),
+	).MarshalBinary()
+	require.NoError(t, err)
+	return obfuscatedBytes(t, Authenticate, body, secret)
+}
+
+func obfuscatedAcctRequestBytes(t testing.TB, secret []byte) []byte {
+	body, err := NewAcctRequest(
+		SetAcctRequestFlag(AcctFlagStart),
+		SetAcctRequestMethod(AuthenMethodTacacsPlus),
+		SetAcctRequestPrivLvl(PrivLvlUser),
+		SetAcctRequestType(AuthenTypeASCII),
+		SetAcctRequestService(AuthenServiceLogin),
+		SetAcctRequestUser("rotation-test"),
+		SetAcctRequestPort("tty0"),
+		SetAcctRequestRemAddr("10.0.0.1"),
+	).MarshalBinary()
+	require.NoError(t, err)
+	return obfuscatedBytes(t, Accounting, body, secret)
+}
+
+func newMultiCrypter(conn net.Conn, primary []byte, alts ...[]byte) *crypter {
+	c := newCrypter(primary, conn, false, false)
+	c.altSecrets = alts
+	return c
+}
+
+func TestMultiSecretSelectsAlternate(t *testing.T) {
+	secretA := []byte("primary-that-is-wrong")
+	secretB := []byte("the-one-the-device-used")
+
+	wire := obfuscatedPacketBytes(t, secretB)
+	c := newMultiCrypter(&mockConnection{data: wire}, secretA, secretB)
+
+	got, err := c.read()
+	require.NoError(t, err, "read should succeed by falling back to secretB")
+
+	// crypter must have latched onto secretB for the rest of the connection.
+	assert.True(t, bytes.Equal(secretB, c.secret), "active secret should be secretB after selection")
+	assert.Nil(t, c.altSecrets, "altSecrets cleared after first read")
+
+	// And the de-obfuscated body must round-trip.
+	var ar AuthorRequest
+	require.NoError(t, Unmarshal(got.Body, &ar))
+	assert.Equal(t, AuthenMethodTacacsPlus, ar.Method)
+	assert.Equal(t, "rotation-test", string(ar.User))
+}
+
+func TestMultiSecretPrimaryUsed(t *testing.T) {
+	secretA := []byte("primary")
+	secretB := []byte("alt-never-tried")
+
+	wire := obfuscatedPacketBytes(t, secretA)
+	c := newMultiCrypter(&mockConnection{data: wire}, secretA, secretB)
+
+	_, err := c.read()
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(secretA, c.secret))
+	assert.Nil(t, c.altSecrets)
+}
+
+func TestMultiSecretAllWrong(t *testing.T) {
+	wire := obfuscatedPacketBytes(t, []byte("device-key"))
+	c := newMultiCrypter(&mockConnection{data: wire}, []byte("wrong-1"), []byte("wrong-2"))
+
+	_, err := c.read()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad secret")
+}
+
+func TestMultiSecretSinglePathUnchanged(t *testing.T) {
+	secret := []byte("only")
+	wire := obfuscatedPacketBytes(t, secret)
+	c := newCrypter(secret, &mockConnection{data: wire}, false, false)
+
+	_, err := c.read()
+	require.NoError(t, err)
+	assert.Nil(t, c.altSecrets)
+}
+
+func TestBadSecretReplyDoesNotMutateHeader(t *testing.T) {
+	h := Header{Type: Authorize, Length: 999, SeqNo: 7}
+	var c crypter
+	_, err := c.badSecretReply(h)
+	require.NoError(t, err)
+	assert.EqualValues(t, 999, h.Length, "caller's Header.Length must be untouched")
+	assert.EqualValues(t, 7, h.SeqNo, "caller's Header.SeqNo must be untouched")
+}
+
+type nopLogger struct{}
+
+func (nopLogger) Infof(context.Context, string, ...interface{})        {}
+func (nopLogger) Errorf(context.Context, string, ...interface{})       {}
+func (nopLogger) Debugf(context.Context, string, ...interface{})       {}
+func (nopLogger) Record(context.Context, map[string]string, ...string) {}
+
+type recordingHandler struct {
+	got    chan Request
+	cancel context.CancelFunc
+}
+
+func (h *recordingHandler) Handle(_ Response, req Request) {
+	h.got <- req
+	h.cancel() // stop the handle() loop after one packet
+}
+
+type multiProvider struct {
+	secrets [][]byte
+	h       Handler
+}
+
+func (m multiProvider) Get(ctx context.Context, remote net.Addr) ([]byte, Handler, error) {
+	s, h, err := m.GetSecrets(ctx, remote)
+	if len(s) == 0 {
+		return nil, h, err
+	}
+	return s[0], h, err
+}
+
+func (m multiProvider) GetSecrets(context.Context, net.Addr) ([][]byte, Handler, error) {
+	return m.secrets, m.h, nil
+}
+
+type singleProvider struct {
+	secret []byte
+	h      Handler
+}
+
+func (s singleProvider) Get(context.Context, net.Addr) ([]byte, Handler, error) {
+	return s.secret, s.h, nil
+}
+
+func TestServerServeMultiSecretPath(t *testing.T) {
+	secretA := []byte("server-primary-wrong")
+	secretB := []byte("server-device-key")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rh := &recordingHandler{got: make(chan Request, 1), cancel: cancel}
+	s := NewServer(nopLogger{}, multiProvider{secrets: [][]byte{secretA, secretB}, h: rh})
+
+	mc := &mockConnection{data: obfuscatedPacketBytes(t, secretB)}
+	s.Add(1)
+	s.serve(ctx, mc)
+
+	select {
+	case req := <-rh.got:
+		var ar AuthorRequest
+		require.NoError(t, Unmarshal(req.Body, &ar))
+		assert.Equal(t, "rotation-test", string(ar.User), "alt secret must have been selected and body de-obfuscated")
+	default:
+		t.Fatal("handler was never invoked; multi-secret path did not reach handle()")
+	}
+}
+
+func TestServerServeSingleSecretPath(t *testing.T) {
+	secret := []byte("only-secret")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rh := &recordingHandler{got: make(chan Request, 1), cancel: cancel}
+	s := NewServer(nopLogger{}, singleProvider{secret: secret, h: rh})
+
+	mc := &mockConnection{data: obfuscatedPacketBytes(t, secret)}
+	s.Add(1)
+	s.serve(ctx, mc)
+
+	select {
+	case req := <-rh.got:
+		var ar AuthorRequest
+		require.NoError(t, Unmarshal(req.Body, &ar))
+		assert.Equal(t, "rotation-test", string(ar.User))
+	default:
+		t.Fatal("handler was never invoked; single-secret fallback path failed")
+	}
+}
+
+func TestServerServeNoSecretsClosesConn(t *testing.T) {
+	s := NewServer(nopLogger{}, multiProvider{secrets: nil, h: nil})
+	mc := &mockConnection{}
+	s.Add(1)
+	s.serve(context.Background(), mc)
+	assert.True(t, mc.closed, "serve must close the conn when provider returns no secrets")
+}
+
+func TestServerServeNilSecretClosesConn(t *testing.T) {
+	// A provider returning a single nil element must be rejected the same as
+	// the upstream nil-secret check; a nil key would obfuscate with an empty key.
+	h := &recordingHandler{got: make(chan Request, 1)}
+	s := NewServer(nopLogger{}, multiProvider{secrets: [][]byte{nil}, h: h})
+	mc := &mockConnection{data: obfuscatedPacketBytes(t, []byte("k"))}
+	s.Add(1)
+	s.serve(context.Background(), mc)
+	assert.True(t, mc.closed, "serve must close the conn when provider returns a nil secret")
+	assert.Len(t, h.got, 0, "handler must not be invoked")
+}
+
+func TestMultiSecretIgnoredOnTLS(t *testing.T) {
+	// On the TLS path there is no obfuscation so altSecrets must not be consulted.
+	wire := obfuscatedPacketBytes(t, []byte("device-key"))
+	// Set the unencrypted flag like a real TLS client would.
+	wire[3] |= byte(UnencryptedFlag)
+	c := newCrypter([]byte("ignored"), &mockConnection{data: wire}, false, true)
+	c.altSecrets = [][]byte{[]byte("also-ignored")}
+	_, _ = c.read()
+	assert.NotNil(t, c.altSecrets, "TLS path must not consume altSecrets")
+}
+
+func TestMultiSecretAcrossPacketTypes(t *testing.T) {
+	secretA := []byte("primary-that-is-wrong")
+	secretB := []byte("the-one-the-device-used")
+
+	for _, tc := range []struct {
+		name string
+		wire []byte
+	}{
+		{"authorize", obfuscatedPacketBytes(t, secretB)},
+		{"authenticate", obfuscatedAuthenStartBytes(t, secretB)},
+		{"accounting", obfuscatedAcctRequestBytes(t, secretB)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newMultiCrypter(&mockConnection{data: tc.wire}, secretA, secretB)
+			_, err := c.read()
+			require.NoError(t, err)
+			assert.True(t, bytes.Equal(secretB, c.secret), "alt secret must be selected for %s", tc.name)
+		})
+	}
+}
+
+func FuzzMultiSecretSelection(f *testing.F) {
+	f.Add([]byte("primary"), []byte("alternate"))
+	f.Add([]byte{0xff, 0x00, 0x7f}, []byte{0x01, 0x02, 0x03, 0x04})
+	f.Fuzz(func(t *testing.T, secretA, secretB []byte) {
+		if len(secretA) == 0 || len(secretB) == 0 || bytes.Equal(secretA, secretB) {
+			t.Skip()
+		}
+		// clone so the obfuscation pad derivation never aliases the
+		// other fuzz input
+		a := bytes.Clone(secretA)
+		b := bytes.Clone(secretB)
+		wire := obfuscatedPacketBytes(t, b)
+
+		// case 1: primary wrong, alt right -> selects b
+		c := newMultiCrypter(&mockConnection{data: bytes.Clone(wire)}, a, b)
+		if _, err := c.read(); err != nil {
+			// detectBadSecret rejected both (false positive on b);
+			// pre-existing behaviour, not the alt path
+			t.Skip()
+		}
+		if bytes.Equal(a, c.secret) {
+			// detectBadSecret accepted the wrong-key body
+			// (no MAC in the obfuscation scheme); upstream would
+			// proceed with garbage here too.  Not the alt path.
+			t.Skip()
+		}
+		if !bytes.Equal(b, c.secret) {
+			t.Fatalf("primary-wrong: selected secret = %x, want %x", c.secret, b)
+		}
+
+		// case 2: primary right, alt unused -> stays b, no fallback
+		c = newMultiCrypter(&mockConnection{data: bytes.Clone(wire)}, b, a)
+		if _, err := c.read(); err != nil {
+			t.Fatalf("primary-right: unexpected read error: %v", err)
+		}
+		if !bytes.Equal(b, c.secret) {
+			t.Fatalf("primary-right: selected secret = %x, want %x (no fallback expected)", c.secret, b)
+		}
+	})
+}
+
+func BenchmarkCrypterReadSingleSecret(b *testing.B) {
+	secret := []byte("benchmark-single")
+	wire := obfuscatedPacketBytes(b, secret)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := newCrypter(secret, &mockConnection{data: bytes.Clone(wire)}, false, false)
+		if _, err := c.read(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCrypterReadWithUnusedAlt(b *testing.B) {
+	secret := []byte("benchmark-single")
+	alts := [][]byte{[]byte("never-used-because-primary-works")}
+	wire := obfuscatedPacketBytes(b, secret)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := newCrypter(secret, &mockConnection{data: bytes.Clone(wire)}, false, false)
+		c.altSecrets = alts
+		if _, err := c.read(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/secret.go
+++ b/secret.go
@@ -18,3 +18,11 @@ import (
 type SecretProvider interface {
 	Get(ctx context.Context, remote net.Addr) ([]byte, Handler, error)
 }
+
+// MultiSecretProvider is an optional extension to SecretProvider.  Implementations
+// return all candidate secrets for a remote.  The server tries each in order on
+// the first packet of a connection and uses the first that yields a parseable
+// body, allowing hitless shared-secret rotation.  The Handler is per-source.
+type MultiSecretProvider interface {
+	GetSecrets(ctx context.Context, remote net.Addr) ([][]byte, Handler, error)
+}

--- a/server.go
+++ b/server.go
@@ -124,8 +124,21 @@ func (s *Server) serve(ctx context.Context, conn net.Conn) {
 	defer timer.ObserveDuration()
 	// start a timer to measure loader duration
 	loaderStart := time.Now()
-	secret, handler, err := s.Get(ctx, conn.RemoteAddr())
-	if err != nil || secret == nil || handler == nil {
+	var (
+		secrets [][]byte
+		handler Handler
+		err     error
+	)
+	if msp, ok := s.SecretProvider.(MultiSecretProvider); ok {
+		secrets, handler, err = msp.GetSecrets(ctx, conn.RemoteAddr())
+	} else {
+		var secret []byte
+		secret, handler, err = s.Get(ctx, conn.RemoteAddr())
+		if secret != nil {
+			secrets = [][]byte{secret}
+		}
+	}
+	if err != nil || len(secrets) == 0 || secrets[0] == nil || handler == nil {
 		s.Errorf(ctx, "ignoring request: %v", err)
 		conn.Close()
 		timer.ObserveDuration()
@@ -133,7 +146,11 @@ func (s *Server) serve(ctx context.Context, conn net.Conn) {
 	}
 	ctx = context.WithValue(ctx, ContextLoaderDuration, time.Since(loaderStart).Milliseconds())
 	serveAccepted.Inc()
-	s.handle(ctx, newCrypter(secret, conn, s.proxy, s.useTLS), handler)
+	cr := newCrypter(secrets[0], conn, s.proxy, s.useTLS)
+	if len(secrets) > 1 {
+		cr.altSecrets = secrets[1:]
+	}
+	s.handle(ctx, cr, handler)
 	serveAccepted.Dec()
 }
 

--- a/stats.go
+++ b/stats.go
@@ -58,6 +58,11 @@ var (
 		Name:      "crypter_badSecret",
 		Help:      "number of bad secrets",
 	})
+	crypterAltSecretSelected = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "tacquito",
+		Name:      "crypter_alt_secret_selected",
+		Help:      "number of connections that selected an alternate secret",
+	})
 	crypterUnmarshalError = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "tacquito",
 		Name:      "crypter_unmarshal_error",
@@ -135,6 +140,7 @@ func init() {
 	prometheus.MustRegister(crypterWrite)
 	prometheus.MustRegister(crypterWriteError)
 	prometheus.MustRegister(crypterBadSecret)
+	prometheus.MustRegister(crypterAltSecretSelected)
 	prometheus.MustRegister(crypterUnmarshalError)
 	prometheus.MustRegister(crypterMarshalError)
 	prometheus.MustRegister(crypterCryptError)


### PR DESCRIPTION
Rotating a TACACS+ shared secret today is a flag-day: whichever side flips
first fails until the other catches up.  `MultiSecretProvider` is an optional
interface that lets a provider return multiple candidate secrets; the server
tries each on the first packet of a connection (using the existing
`detectBadSecret` check) and latches the one that parses.

Existing `SecretProvider` implementations are unaffected and the single-secret
read path is unchanged.

`badSecretReply` and `unsetFlagReply` now take `Header` by value; building the
reply was mutating the caller's request header, which the retry loop needs to
stay stable across attempts.